### PR TITLE
Add ProcessExecuter#execute to execute a command and return the result

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Test User
+Copyright (c) 2022 James Couball
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
-# ProcessExecuter
+# The ProcessExecuter Gem
 
-**THIS PROJECT IS A WORK IN PROGRESS AND IS NOT USEFUL IN ITS CURRENT STATE**
-
-Welcome to your new gem! In this directory, you'll find the files you need to be
-able to package up your Ruby library into a gem. Put your Ruby code in the file
-`lib/process_executer`. To experiment with that code, run `bin/console` for an
-interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+An API for executing commands in a subprocess
 
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
 
-    bundle add process_executer
+```shell
+bundle add process_executer
+```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    gem install process_executer
+```shell
+gem install process_executer
+```
 
 ## Usage
 
-TODO: Write usage instructions here
+See the examples in the project's YARD documentation.
 
 ## Development
 
@@ -38,7 +35,28 @@ commits and the created tag, and push the `.gem` file to
 ## Contributing
 
 Bug reports and pull requests are welcome on our
-[GitHub issue tracker](https://github.com/[USERNAME]/process_executer)
+[GitHub issue tracker](https://github.com/main-branch/process_executer)
+
+## Feature Checklist
+
+Here is the 1.0 feature checklist:
+
+* [x] Run a command
+* [x] Collect the command's stdout/stderr to a string
+* [x] Passthru the command's stdout/stderr to this process's stdout/stderr
+* [ ] Command execution timeout
+* [ ] Redirect stdout/stderr to a named file
+* [ ] Redirect stdout/stderr to a named file with open mode
+* [ ] Redirect stdout/stderr to a named file with open mode and permissions
+* [ ] Redirect stdout/stderr to an open File object
+* [ ] Merge stdout & stderr
+* [ ] Redirect a file to stdin
+* [ ] Redirect from a butter to stdin
+* [ ] Binary vs. text mode for stdin/stdout/stderr
+* [ ] Environment isolation like Process.spawn
+* [ ] Pass options to Process.spawn (chdir, umask, pgroup, etc.)
+* [ ] Don't allow optionis to Process.spawn that would break the functionality
+    (:in, :out, :err, integer, #fileno, :close_others)
 
 ## License
 

--- a/lib/process_executer.rb
+++ b/lib/process_executer.rb
@@ -1,8 +1,225 @@
 # frozen_string_literal: true
 
-require_relative 'process_executer/version'
+# rubocop:disable Style/SingleLineMethods
 
-module ProcessExecuter
-  class Error < StandardError; end
-  # Your code goes here...
+require 'process_executer/result'
+# require 'nio'
+
+# Execute a process and capture the output to a string, a file, and/or
+# pass the output through to this process's stdout/stderr.
+#
+# @api public
+#
+class ProcessExecuter
+  # stdout collected from the command
+  #
+  # @example
+  #   command = ProcessExecuter.new
+  #   command.execute('echo hello')
+  #   command.out # => "hello\n"
+  #
+  # @return [String, nil] nil if collect_out? is false
+  #
+  attr_reader :out
+
+  # stderr collected from the command
+  #
+  # @example
+  #   command = ProcessExecuter.new
+  #   command.execute('echo hello 1>&2')
+  #   command.err # => "hello\n"
+  #
+  # @return [String, nil] nil if collect_err? is false
+  #
+  attr_reader :err
+
+  # The status of the command process
+  #
+  # Will be `nil` if the command has not completed execution.
+  #
+  # @example
+  #   command = ProcessExecuter.new
+  #   command.execute('echo hello')
+  #   command.status # => #<Process::Status: pid 86235 exit 0>
+  #
+  # @return [Process::Status, nil]
+  #
+  attr_reader :status
+
+  # Show the command's stdout on this process's stdout
+  #
+  # @example
+  #   command = ProcessExecuter.new(passthru_out: true)
+  #   command.passthru_out? # => true
+  #
+  # @return [Boolean]
+  #
+  def passthru_out?; !!@passthru_out; end
+
+  # Show the command's stderr on this process's stderr
+  #
+  # @example
+  #   command = ProcessExecuter.new(passthru_err: true)
+  #   command.passthru_err? # => true
+  #
+  # @return [Boolean]
+  #
+  def passthru_err?; !!@passthru_err; end
+
+  # Collect the command's stdout the :out string (default is true)
+  #
+  # @example
+  #   command = ProcessExecuter.new(collect_out: false)
+  #   command.collect_out? # => false
+  #
+  # @return [Boolean]
+  #
+  def collect_out?; !!@collect_out; end
+
+  # Collect the command's stderr the :err string (default is true)
+  #
+  # @example
+  #   command = ProcessExecuter.new(collect_err: false)
+  #   command.collect_err? # => false
+  #
+  # @return [Boolean]
+  #
+  def collect_err?; !!@collect_err; end
+
+  # Create a new ProcessExecuter
+  #
+  # @example
+  #   command = ProcessExecuter.new(passthru_out: false, passthru_err: false)
+  #
+  # @param passthru_out [Boolean] show the command's stdout on this process's stdout
+  # @param passthru_err [Boolean] show the command's stderr on this process's stderr
+  # @param collect_out [Boolean] collect the command's stdout the :out string
+  # @param collect_err [Boolean] collect the command's stderr the :err string
+  #
+  def initialize(passthru_out: false, passthru_err: false, collect_out: true, collect_err: true)
+    @passthru_out = passthru_out
+    @passthru_err = passthru_err
+    @collect_out = collect_out
+    @collect_err = collect_err
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+
+  # Execute the given command in a subprocess
+  #
+  # See Process.spawn for acceptable values for command and options.
+  #
+  # Do no specify the following options: :in, :out, :err, integer, #fileno, :close_others.
+  #
+  # @example Execute a command as a single string
+  #   result = ProcessExecuter.new.execute('echo hello')
+  #
+  # @example Execute a command as with each argument as a separate string
+  #  result = ProcessExecuter.new.execute('echo', 'hello')
+  #
+  # @example Execute a command in a specific directory
+  #  result = ProcessExecuter.new.execute('pwd', chdir: '/tmp')
+  #  result.out # => "/tmp\n"
+  #
+  # @example Execute a command with specific environment variables
+  #  result = ProcessExecuter.new.execute({ 'FOO' => 'bar' }, 'echo $FOO' )
+  #  result.out # => "bar\n"
+  #
+  # @param command [String, Array<String>] the command to pass to Process.spawn
+  # @param options [Hash] options to pass to Process.spawn
+  #
+  # @return [ProcessExecuter::Result] the result of the command execution
+  #
+  def execute(*command, **options)
+    @status = nil
+    @out = (collect_out? ? '' : nil)
+    @err = (collect_err? ? '' : nil)
+
+    out_reader, out_writer = IO.pipe
+    err_reader, err_writer = IO.pipe
+
+    options[:out] = out_writer
+    options[:err] = err_writer
+
+    pid = Process.spawn(*command, options)
+
+    loop do
+      read_command_output(out_reader, err_reader)
+
+      _pid, @status = Process.wait2(pid, Process::WNOHANG)
+      break if @status
+
+      # puts "finished_pid: #{finished_pid}"
+      # puts "status: #{status}"
+
+      # puts 'starting select'
+      # readers, writers, exceptions = IO.select([stdout_reader, stderr_reader], nil, nil, 0.1)
+      IO.select([out_reader, err_reader], nil, nil, 0.05)
+
+      # puts "readers: #{readers}"
+      # puts "writers: #{writers}"
+      # puts "exceptions: #{exceptions}"
+
+      # break unless readers || writers || exceptions
+
+      _pid, @status = Process.wait2(pid, Process::WNOHANG)
+      break if @status
+
+      # puts "finished_pid: #{finished_pid}"
+      # puts "status: #{status}"
+    end
+
+    out_writer.close
+    err_writer.close
+
+    # Read whatever is left over after the process terminates
+    read_command_output(out_reader, err_reader)
+    ProcessExecuter::Result.new(@status, @out, @err)
+  end
+
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+
+  private
+
+  # Read output from the given readers
+  # @return [void]
+  # @api private
+  def read_command_output(out_reader, err_reader)
+    loop do
+      # Keep reading until there is nothing left to read
+      break unless read_out(out_reader) || read_err(err_reader)
+    end
+  end
+
+  # Read stdout from the given reader
+  # @return [void]
+  # @api private
+  def read_out(reader)
+    new_data = reader.read_nonblock(1024)
+    # puts "new_stdout: '#{new_data}'"
+    @out += new_data if new_data && collect_out?
+    puts new_data if new_data && passthru_out?
+    true
+  rescue EOFError, IO::EAGAINWaitReadable
+    # Nothing to read at this time
+    false
+  end
+
+  # Read stderr from the given reader
+  # @return [void]
+  # @api private
+  def read_err(reader)
+    new_data = reader.read_nonblock(1024)
+    # puts "new_stderr: '#{new_data}'"
+    @err += new_data if new_data && collect_err?
+    warn new_data if new_data && passthru_err?
+    true
+  rescue EOFError, IO::EAGAINWaitReadable
+    # Nothing to read at this time
+    false
+  end
 end
+
+# rubocop:enable Style/SingleLineMethods

--- a/lib/process_executer/result.rb
+++ b/lib/process_executer/result.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class ProcessExecuter
+  # The result of executing a command
+  #
+  # @api public
+  #
+  class Result
+    # The status of the command process
+    #
+    # @example
+    #   status # => #<Process::Status: pid 86235 exit 0>
+    #   out = 'hello'
+    #   err = 'ERROR'
+    #   command = ProcessExecuter.new(status, out, err)
+    #   command.status # => #<Process::Status: pid 86235 exit 0>
+    #
+    # @return [Process::Status]
+    #
+    attr_reader :status
+
+    # The command's stdout (if collected)
+    #
+    # @example
+    #   status # => #<Process::Status: pid 86235 exit 0>
+    #   out = 'hello'
+    #   err = 'ERROR'
+    #   command = ProcessExecuter.new(status, out, err)
+    #   command.out # => "hello\n"
+    #
+    # @return [String, nil]
+    #
+    attr_reader :out
+
+    # The command's stderr (if collected)
+    #
+    # @example
+    #   status # => #<Process::Status: pid 86235 exit 0>
+    #   out = 'hello'
+    #   err = 'ERROR'
+    #   command = ProcessExecuter.new(status, out, err)
+    #   command.out # => "ERROR\n"
+    #
+    # @return [String, nil]
+    #
+    attr_reader :err
+
+    # Create a new Result object
+    #
+    # @example
+    #   status # => #<Process::Status: pid 86235 exit 0>
+    #   out = 'hello'
+    #   err = 'ERROR'
+    #   command = ProcessExecuter.new(status, out, err)
+    #
+    # @param status [Process::Status] the status of the command process
+    # @param out [String, nil] the command's stdout (if collected)
+    # @param err [String, nil] the command's stderr (if collected)
+    #
+    # @return [ProcessExecuter::Result] the result object
+    #
+    def initialize(status, out, err)
+      @status = status
+      @out = out
+      @err = err
+    end
+  end
+end

--- a/lib/process_executer/version.rb
+++ b/lib/process_executer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module ProcessExecuter
+class ProcessExecuter
   VERSION = '0.1.0'
 end

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -8,17 +8,17 @@ Gem::Specification.new do |spec|
   spec.authors = ['James Couball']
   spec.email = ['jcouball@yahoo.com']
 
-  spec.summary = 'An API for executing processes'
-  spec.description = 'An API for executing processes'
-  spec.homepage = 'https://github.com/main_branch/process_executor'
+  spec.summary = 'An API for executing commands in a subprocess'
+  spec.description = 'An API for executing commands in a subprocess'
+  spec.homepage = 'https://github.com/main_branch/process_executer'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.7.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/main_branch/process_executor'
-  spec.metadata['changelog_uri'] = 'https://github.com/main_branch/process_executor'
+  spec.metadata['source_code_uri'] = 'https://github.com/main_branch/process_executer'
+  spec.metadata['changelog_uri'] = 'https://github.com/main_branch/process_executer'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/process_executer_spec.rb
+++ b/spec/process_executer_spec.rb
@@ -1,7 +1,177 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe ProcessExecuter do
   it 'has a version number' do
     expect(ProcessExecuter::VERSION).not_to be nil
+  end
+
+  describe 'execute' do
+    subject { ProcessExecuter.new(**options).execute(*command) }
+
+    let(:options) { {} }
+
+    let(:command) { %w[ruby test_script.rb] }
+
+    before(:each) do
+      @temp_dir = Dir.mktmpdir
+      @saved_dir = Dir.pwd
+      Dir.chdir(@temp_dir)
+      File.write('test_script.rb', script)
+    end
+
+    after(:each) do
+      Dir.chdir(@saved_dir)
+      FileUtils.rm_rf(@temp_dir)
+    end
+
+    context 'with a simple command' do
+      let(:script) { <<~SCRIPT }
+        require 'fileutils'
+        FileUtils.touch('test.txt')
+      SCRIPT
+
+      it 'executes the command' do
+        subject
+        expect(File.exist?('test.txt')).to be true
+      end
+
+      it 'returns a ProcessExecuter::Result' do
+        expect(subject).to be_a(ProcessExecuter::Result)
+      end
+
+      it 'should run successfully' do
+        expect(subject.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'with a command that outputs to stdout' do
+      let(:script) { <<~SCRIPT }
+        puts('Hello World')
+        STDOUT.flush
+        puts('Goodbye World')
+      SCRIPT
+
+      it 'should capture stdout' do
+        expect(subject.out).to eq("Hello World\nGoodbye World\n")
+      end
+    end
+
+    context 'with a command that outputs to stderr' do
+      let(:script) { <<~SCRIPT }
+        STDERR.puts('Hello World')
+        STDERR.flush
+        STDERR.puts('Goodbye World')
+      SCRIPT
+
+      it 'should capture stderr' do
+        expect(subject.err).to eq("Hello World\nGoodbye World\n")
+      end
+    end
+
+    context 'with a command that outputs to stdout a little bit over time' do
+      let(:script) { <<~SCRIPT }
+        puts('Hello World')
+        STDOUT.flush
+        sleep 0.5
+        puts('Hello?')
+        STDOUT.flush
+        sleep 0.5
+        puts('Is this thing on?')
+        STDOUT.flush
+      SCRIPT
+
+      it 'should capture everything output to stdout' do
+        expect(subject.out).to eq("Hello World\nHello?\nIs this thing on?\n")
+      end
+    end
+
+    context 'with a command that outputs to both stdout and stderr' do
+      let(:script) { <<~SCRIPT }
+        puts('Processing "Hello World"...')
+        warn('Error: "Hello World" is not a valid input')
+        puts('DONE WITH ERROR')
+      SCRIPT
+
+      it 'should capture stdout and stderr' do
+        expect(subject.out).to eq("Processing \"Hello World\"...\nDONE WITH ERROR\n")
+        expect(subject.err).to eq("Error: \"Hello World\" is not a valid input\n")
+      end
+    end
+
+    context 'with a command that outputs to out and err' do
+      let(:out) { 'Some output' }
+      let(:err) { 'ERROR' }
+      let(:expected_out) { "#{out}\n" }
+      let(:expected_err) { "#{err}\n" }
+      let(:nothing) { '' }
+
+      let(:script) { <<~SCRIPT }
+        puts('#{out}')
+        warn('#{err}')
+      SCRIPT
+
+      describe '(testing collect_out and collect_err flags)' do
+        context 'when collect_out AND collect_err are false' do
+          let(:options) { { collect_out: false, collect_err: false } }
+          let(:expected_out) { nil }
+          let(:expected_err) { nil }
+
+          it 'should not collect stdout and stderr in :out and :err' do
+            expect(subject).to have_attributes(out: expected_out, err: expected_err)
+          end
+        end
+
+        context 'when collect_out is false' do
+          let(:options) { { collect_out: false } }
+          let(:expected_out) { nil }
+
+          it 'should not collect stdout in :out' do
+            expect(subject).to have_attributes(out: expected_out, err: expected_err)
+          end
+        end
+
+        context 'when collect_err is false' do
+          let(:options) { { collect_err: false } }
+          let(:expected_err) { nil }
+
+          it 'should not collect stderr in :err' do
+            expect(subject).to have_attributes(out: expected_out, err: expected_err)
+          end
+        end
+      end
+
+      describe '(testing passthru_out and passthru_err flags)' do
+        context 'when passthru_out is true' do
+          let(:options) { { passthru_out: true } }
+
+          it 'should pass thru stdout but not stderr AND still collect both stdout and stderr' do
+            result = nil
+            expect { result = subject }.to(output("#{out}\n").to_stdout.and(output(nothing).to_stderr))
+            expect(result).to have_attributes(out: "#{out}\n", err: "#{err}\n")
+          end
+        end
+
+        context 'when passthru_err is true' do
+          let(:options) { { passthru_err: true } }
+          it 'should pass thru stderr but not stdout AND still collect both stdout and stderr' do
+            result = nil
+            expect { result = subject }.to(output(nothing).to_stdout.and(output("#{err}\n").to_stderr))
+            expect(result).to have_attributes(out: "#{out}\n", err: "#{err}\n")
+          end
+        end
+
+        context 'when both stdpassthru_out and stdpassthru_err are true' do
+          let(:options) { { passthru_out: true, passthru_err: true } }
+
+          it 'should pass thru stderr and stdout AND still collect both stdout and stderr' do
+            result = nil
+            expect { result = subject }.to(output("#{out}\n").to_stdout.and(output("#{err}\n").to_stderr))
+            expect(result).to have_attributes(out: "#{out}\n", err: "#{err}\n")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add the following features:

* Run a command in a subprocess returning a 'ProcessExecuter::Result' blocking until the command has completed:

    ```ruby
    require 'process_executer'
    result = ProcessExecuter.new.execute('echo hello')
    result.out # => "hello\n"
    result.err # => ""
    result.status # => #<Process::Status: pid 86235 exit 0>
    ```

* Command stdout is collected in `result.out` (can be supressed with the `collect_out: false` arg to `initialize`)
* Command stderr is collected in `result.in`  (can be supressed with the `collect_err: false` arg to `initialize`)

    ```ruby
    require 'process_executer'
    command = ProcessExecuter.new
    result = command.execute('echo hello', collect_out: false, collect_err: false)
    result.out # => nil
    result.err # => nil
    result.status # => #<Process::Status: pid 86235 exit 0>
    ```

* The command's stdout/stderr can be passed through to the calling process's stdout/stderr using the
  `passthru_out: true` and `passthru_err: true` args to `initialize`
