### PR TITLE
Use the create_github_release gem to make the release PR

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -9,7 +9,7 @@ MD013: { line_length: 90, tables: false, code_blocks: false }
 # Heading duplication is allowed for non-sibling headings
 MD024: { siblings_only: true }
 
-# Do not allow the specified trailig punctuation in a header
+# Do not allow the specified trailing punctuation in a header
 MD026: { punctuation: '.,;:' }
 
 # Order list items must have a prefix that increases in numerical order

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -35,11 +35,13 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_development_dependency 'bump', '~> 0.10'
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
+  spec.add_development_dependency 'create_github_release', '~> 0.2'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'solargraph', '~> 0.47'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'
 


### PR DESCRIPTION
This PR adds the following changes:

* Add a dev dependency on the create_github_release gem so it can be used to make the release PR.
* Add a dev dependency on solargraph so vscode can use it
* Fix an unrelated typo in a comment
