### PR TITLE
Add CodeClimate badges to README.md

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,29 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
+
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    name: Report test coverage to CodeClimate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake spec
+
+      - name: Report test coverage
+        uses: paambaati/codeclimate-action@v3.2.0
+        env:
+          CC_TEST_REPORTER_ID: d3bf532dce7cc5d9ae5ae10efd7708d8465d3cc6236e5e11377cbef62ed2b32f
+        with:
+          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "paambaati"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # The ProcessExecuter Gem
 
+[![Gem Version](https://badge.fury.io/rb/process_executer.svg)](https://badge.fury.io/rb/process_executer)
+[![Build Status](https://github.com/main-branch/process_executer/workflows/Ruby/badge.svg?branch=main)](https://github.com/main-branch/process_executer/actions?query=workflow%3ARuby)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/maintainability)](https://codeclimate.com/github/main-branch/process_executer/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/test_coverage)](https://codeclimate.com/github/main-branch/process_executer/test_coverage)
+
 An API for executing commands in a subprocess
 
 ## Installation

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'solargraph', '~> 0.47'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,9 @@ end
 # Setup simplecov
 
 require 'simplecov'
+require 'simplecov-lcov'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
+SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
 
 # Fail the rspec run if code coverage falls below the configured threshold
 #


### PR DESCRIPTION
This PR adds the maintainability and code coverage badges to the README.md by making the following changes:

* Generate an LCOV formatted unit test coverage report
* Report coverage statistics to CodeClimate
* Add the maintainability and code coverages badges to the README.md