### PR TITLE
Increase default chunk_size to 100_000 bytes

### DIFF
--- a/lib/process_executer/monitored_pipe.rb
+++ b/lib/process_executer/monitored_pipe.rb
@@ -52,7 +52,7 @@ module ProcessExecuter
     # @param writers [Array<#write>] as data is read from the pipe, it is written to these writers
     # @param chunk_size [Integer] the size of the chunks to read from the pipe
     #
-    def initialize(*writers, chunk_size: 1000)
+    def initialize(*writers, chunk_size: 100_000)
       @writers = writers
       @chunk_size = chunk_size
       @pipe_reader, @pipe_writer = IO.pipe

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # SimpleCov in JRuby reports the following line as not covered even though it is
       # :nocov:
       expect(monitored_pipe).to have_attributes(
-        thread: Thread, writers: writers, pipe_reader: IO, pipe_writer: IO, chunk_size: 1000
+        thread: Thread, writers: writers, pipe_reader: IO, pipe_writer: IO, chunk_size: 100_000
       )
       # :nocov:
     end
@@ -106,6 +106,15 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         sleep 0.2
         monitored_pipe.close
         expect(output.string).to eq('hello world')
+      end
+    end
+
+    context 'with a large amount of data' do
+      it 'should write all the data to the writer' do
+        data = 'h' * 50_000_000
+        monitored_pipe.write(data)
+        monitored_pipe.close
+        expect(output.string.size).to eq(data.size)
       end
     end
   end


### PR DESCRIPTION
Add test for reading a large amount of data written to the subprocess stdout. In order to get this to work, the default chunk_size needed to be increased to 100_000 bytes.