### PR TITLE
Handle exceptions from writers within MonitoredPipe

### DIFF
--- a/lib/process_executer/monitored_pipe.rb
+++ b/lib/process_executer/monitored_pipe.rb
@@ -279,7 +279,10 @@ module ProcessExecuter
     # @api private
     def monitor_pipe
       new_data = pipe_reader.read_nonblock(chunk_size)
+      # SimpleCov under JRuby reports the begin statement as not covered, but it is
+      # :nocov:
       begin
+        # :nocov:
         writers.each { |w| w.write(new_data) }
       rescue StandardError => e
         @exception = e

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -143,26 +143,26 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
 
       it 'should kill the monitoring thread' do
         monitored_pipe.write('hello')
-        sleep(0.01)
+        sleep(0.02)
         expect(monitored_pipe.thread.alive?).to eq(false)
       end
 
       it 'should set the state to :closed' do
         monitored_pipe.write('hello')
-        sleep(0.01)
+        sleep(0.02)
         expect(monitored_pipe.state).to eq(:closed)
       end
 
       it 'should save the exception raised to #exception' do
         monitored_pipe.write('hello')
-        sleep(0.01)
+        sleep(0.02)
         expect(monitored_pipe.exception).to be_a(Encoding::UndefinedConversionError)
         expect(monitored_pipe.exception.message).to eq('UTF-8 conversion error')
       end
 
       it 'should raise an exception if #write is called after the pipe is closed' do
         monitored_pipe.write('hello')
-        sleep(0.01)
+        sleep(0.02)
         expect { monitored_pipe.write('world') }.to raise_error(IOError, 'closed stream')
       end
     end


### PR DESCRIPTION
MonitoredPipe will handle exceptions within a writer in the following way:
* the exception will be saved to the `#exception` attribute
* the pipe will be closed (setting `#state` to `:closed`)
* the monitoring thread will be killed

Any further writes to this pipe will cause an IOError exception to be raised.