### PR TITLE
Use latest create_release_version gem

### DIFF
--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_development_dependency 'bump', '~> 0.10'
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 0.2'
+  spec.add_development_dependency 'create_github_release', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.36'


### PR DESCRIPTION
This gem provides the `create-github-release` script which is used to create the release for this gem.

Upgrade to the 1.x major version of this gem.