### PR TITLE
Reduce the time spent waiting for output

### DIFF
--- a/lib/process_executer/monitored_pipe.rb
+++ b/lib/process_executer/monitored_pipe.rb
@@ -86,7 +86,7 @@ module ProcessExecuter
       return unless state == :open
 
       @state = :closing
-      sleep 0.01 until state == :closed
+      sleep 0.001 until state == :closed
     end
 
     # Return the write end of the pipe so that data can be written to it
@@ -149,6 +149,8 @@ module ProcessExecuter
     # @api private
     #
     def write(data)
+      raise IOError, 'closed stream' unless state == :open
+
       pipe_writer.write(data)
     end
 
@@ -289,7 +291,7 @@ module ProcessExecuter
         @state = :closing
       end
     rescue IO::WaitReadable
-      pipe_reader.wait_readable(0.01)
+      pipe_reader.wait_readable(0.001)
     end
 
     # Read any remaining data from the pipe and close it

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -166,5 +166,12 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         expect { monitored_pipe.write('world') }.to raise_error(IOError, 'closed stream')
       end
     end
+
+    context 'after the pipe is closed' do
+      it 'should raise an exception' do
+        monitored_pipe.close
+        expect { monitored_pipe.write('hello') }.to raise_error(IOError, 'closed stream')
+      end
+    end
   end
 end


### PR DESCRIPTION
Reduce the time spent waiting for the pipe to close and for input to happen.

This has greatly increased the performance this gem.