### PR TITLE
Update the minimum supported version of Ruby from 2.7.x to 3.0.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,20 +1,39 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+    # The default triggers for pull requests are opened, synchronize, and reopened.
+    # Add labeled and unlabeled to the list of triggers so that the
+    # check_for_semver_pr_label job is run when a label is added or removed from a
+    # pull request.
+
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
+  check_for_semver_pr_label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check that a semver label is present on the PR
+        if: github.event_name == 'pull_request'
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major,minor,patch,trivial
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
-    continue-on-error: true
+    needs: [check_for_semver_pr_label]
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3', 'head', 'jruby-head', 'truffleruby-head']
+        ruby:
+          ["3.0", "3.1", "3.2", "3.3", "head", "jruby-head", "truffleruby-head"]
         operating-system: [ubuntu-latest]
         include:
           - ruby: 3.0
@@ -45,7 +64,7 @@ jobs:
         run: bundle exec rake
 
   coverage:
-    needs: [ build ]
+    needs: [build]
     runs-on: ubuntu-latest
 
     name: Report test coverage to CodeClimate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,12 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', 'head', 'jruby-head', 'truffleruby-head']
+        ruby: ['3.0', '3.1', '3.2', '3.3', 'head', 'jruby-head', 'truffleruby-head']
         operating-system: [ubuntu-latest]
         include:
-          - ruby: 3.1
+          - ruby: 3.0
+            operating-system: windows-latest
+          - ruby: 3.3
             operating-system: windows-latest
           # - ruby: jruby-head
           #   operating-system: windows-latest
@@ -55,7 +57,7 @@ jobs:
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Run tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   SuggestExtensions: false
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
   # your project supports:
   TargetRubyVersion: 2.7
 
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # The default max line length is 80 characters
 Layout/LineLength:
   Max: 120
@@ -16,5 +19,18 @@ Layout/LineLength:
 # The DSL for RSpec and the gemspec file make it very hard to limit block length:
 Metrics/BlockLength:
   Exclude:
+    - "spec/spec_helper.rb"
     - "spec/**/*_spec.rb"
     - "*.gemspec"
+
+Metrics/ModuleLength:
+  CountAsOne: ['hash']
+
+# When writing minitest tests, it is very hard to limit test class length:
+Metrics/ClassLength:
+  CountAsOne: ['hash']
+  Exclude:
+    - "test/**/*_test.rb"
+
+Style/AsciiComments:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/maintainability)](https://codeclimate.com/github/main-branch/process_executer/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/test_coverage)](https://codeclimate.com/github/main-branch/process_executer/test_coverage)
 
+* [Features](#features)
+  * [ProcessExecuter::MonitoredPipe](#processexecutermonitoredpipe)
+  * [ProcessExecuter.spawn](#processexecuterspawn)
+* [Installation](#installation)
+* [Usage](#usage)
+* [Development](#development)
+* [Releasing](#releasing)
+* [Determine Semver increment](#determine-semver-increment)
+* [Contributing](#contributing)
+* [License](#license)
+
 ## Features
 
 [Full YARD documentation](https://rubydoc.info/gems/process_executer/) for this
@@ -92,11 +103,52 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run
 `rake spec` to run the tests. You can also run `bin/console` for an interactive
 prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To
-release a new version, update the version number in `version.rb`, and then run
-`bundle exec rake release`, which will create a git tag for the version, push git
-commits and the created tag, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+## Releasing
+
+To release a new version, first determine the proper semver increment based on the
+type of changes made in the release as described in [Determine Semver
+increment](#determine-semver-increment).
+
+In the root directory of the project with the `main` branch checked out, run the
+following command:
+
+```shell
+create-github-release {major|minor|patch}`
+```
+
+Follow the directions given by the `create-github-release` to publish the new version
+of the gem.
+
+## Determine Semver increment
+
+When creating a new release, determine the semver increment according to the following
+rules.
+
+* `major`: When making incompatible API changes, increment the MAJOR version.
+
+  This typically occurs when the changes introduced would break existing code that
+  depends on this gem. For example, removing a public method, changing a method's
+  signature, or altering the expected behavior of a method in a way that would
+  require changes in the dependent code.
+
+* `minor`: When adding functionality in a backward-compatible manner, increment the
+  MINOR version.
+
+  This includes adding new features, enhancements, or deprecating existing features
+  (as long as the deprecation itself doesn't break compatibility).
+
+  It's also common to include substantial improvements or optimizations in this
+  category, as long as they don't alter the expected behavior of the existing API.
+
+* `patch`: When making backward-compatible bug fixes, increment the PATCH version.
+
+  This is for small changes that fix issues without adding new functionality or
+  altering existing functionality (beyond the scope of fixing a bug).
+
+  It can also include internal changes that don't affect the API, like refactoring
+  code, improving performance, or updating documentation.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,10 +31,6 @@ end
 CLEAN << 'pkg'
 CLOBBER << 'Gemfile.lock'
 
-# Bump
-
-require 'bump/tasks'
-
 # RSpec
 
 require 'rspec/core/rake_task'

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -31,19 +31,17 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_development_dependency 'bump', '~> 0.10'
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '~> 1.36'
-  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'create_github_release', '~> 1.1'
+  spec.add_development_dependency 'rake', '~> 13.1'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'rubocop', '~> 1.59'
+  spec.add_development_dependency 'semverify', '~> 0.3'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
   unless RUBY_PLATFORM == 'java'
-    spec.add_development_dependency 'redcarpet', '~> 3.5'
+    spec.add_development_dependency 'redcarpet', '~> 3.6'
     spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     spec.add_development_dependency 'yardstick', '~> 0.9'
   end

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'An API for executing commands in a subprocess'
   spec.homepage = 'https://github.com/main-branch/process_executer'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'solargraph', '~> 0.47'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.5'


### PR DESCRIPTION
Update the minimum supported version of Ruby from 2.7.x to 3.0.x

In order to do this, the following changes were made:
* Update minimum supported Ruby version from 2.7.x to 3.0.x
* Update dependencies to latest versions
* Remove solargraph as a development dependency as it doesn't build on all platforms
* Update Rubocop configuration based on new cops
* Update rspec configuration to be consistent with other projects in the [main-branch](https://github.com/main-branch) Github org
* Remove bump from the project replacing it with semverify
* Document how to make a new release using `create-github-release`
