### PR TITLE
Enforce that a semver label is present on PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,28 +2,34 @@ name: Continuous Integration
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+    # The default triggers for pull requests are opened, synchronize, and reopened.
+    # Add labeled and unlabeled to the list of triggers so that the
+    # check_for_semver_pr_label job is run when a label is added or removed from a
+    # pull request.
+
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   build:
-    continue-on-error: true
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', 'head', 'jruby-head', 'truffleruby-head']
+        ruby:
+          ["2.7", "3.0", "3.1", "3.2", "head", "jruby-head", "truffleruby-head"]
         operating-system: [ubuntu-latest]
         include:
           - ruby: 3.1
             operating-system: windows-latest
           # - ruby: jruby-head
           #   operating-system: windows-latest
-
-    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
-    runs-on: ${{ matrix.operating-system }}
 
     env:
       JAVA_OPTS: -Djdk.io.File.enableADS=true
@@ -42,11 +48,21 @@ jobs:
       - name: Run rake
         run: bundle exec rake
 
-  coverage:
-    needs: [ build ]
+  check_for_semver_pr_label:
     runs-on: ubuntu-latest
 
+    steps:
+      - name: Check that a semver label is present on the PR
+        if: github.event_name == 'pull_request'
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major-change,minor-change,patch-change,internal-change
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage:
     name: Report test coverage to CodeClimate
+    needs: [ build ]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,7 +1,7 @@
 default: true
 
 # Unordered list indentation
-MD007: { indent: 4 }
+MD007: { indent: 2 }
 
 # Line length
 MD013: { line_length: 90, tables: false, code_blocks: false }

--- a/README.md
+++ b/README.md
@@ -7,10 +7,21 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/maintainability)](https://codeclimate.com/github/main-branch/process_executer/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/0b5c67e5c2a773009cd0/test_coverage)](https://codeclimate.com/github/main-branch/process_executer/test_coverage)
 
-## Features
+* [Usage](#usage)
+  * [ProcessExecuter::MonitoredPipe](#processexecutermonitoredpipe)
+  * [ProcessExecuter.spawn](#processexecuterspawn)
+* [Installation](#installation)
+* [Contributing](#contributing)
+  * [Reporting Issues](#reporting-issues)
+  * [Developing](#developing)
+  * [Submitting Pull Requests](#submitting-pull-requests)
+  * [Releasing](#releasing)
+* [License](#license)
+
+## Usage
 
 [Full YARD documentation](https://rubydoc.info/gems/process_executer/) for this
-gem is hosted on RubyGems.org.
+gem is hosted on RubyGems.org. Read below of an overview and several examples.
 
 This gem contains the following important classes:
 
@@ -18,7 +29,7 @@ This gem contains the following important classes:
 
 `ProcessExecuter::MonitoredPipe` streams data sent through a pipe to one or more writers.
 
-When a new `MonitoredPipe` is created, an pipe is created (via IO.pipe) and
+When a new `MonitoredPipe` is created, a pipe is created (via IO.pipe) and
 a thread is created which reads data as it is written written to the pipe.
 
 Data that is read from the pipe is written one or more writers passed to
@@ -82,27 +93,84 @@ If bundler is not being used to manage dependencies, install the gem by executin
 gem install process_executer
 ```
 
-## Usage
-
-See the examples in the project's YARD documentation.
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To
-release a new version, update the version number in `version.rb`, and then run
-`bundle exec rake release`, which will create a git tag for the version, push git
-commits and the created tag, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
-
 ## Contributing
 
-Bug reports and pull requests are welcome on our
-[GitHub issue tracker](https://github.com/main-branch/process_executer)
+### Reporting Issues
+
+Bug reports and other support requests are welcome on [this project's
+GitHub issue tracker](https://github.com/main-branch/process_executer)
+
+### Developing
+
+Clone the repo, run `bin/setup` to install dependencies, and then run `rake spec` to
+run the tests. You can also run `bin/console` for an interactive prompt that will
+allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+### Submitting Pull Requests
+
+In order for a pull request to be merged, it must be approved by a code owner and
+include a semver label.
+
+The approval must be done using the Github PR Review process by a code owner defined
+in the project's CODEOWNERS file.
+
+The semver label indicates the type of change so that the gem version can be
+increments according to semver rules prior to release. One and only one of the
+following labels must added to the PR:
+
+* **`major-change`**
+
+  Use when the PR includes incompatible API or functional changes.
+
+  This typically occurs when the changes introduced could break existing code that
+  depends on this gem. For example, removing a public method, changing a method's
+  signature, or altering the expected behavior of a method in a way that would
+  require changes in the dependent code.
+
+* **`minor-change`**
+
+  Use when the PR adds functionality in a backward-compatible manner.
+
+  This includes adding new features, enhancements, or deprecating existing features
+  as long as the deprecation itself doesn't break compatibility.
+
+  It's also common to include substantial improvements or optimizations in this
+  category, as long as they don't alter the expected behavior of the existing API.
+
+* **`patch-change`**
+
+  Use when the PR includes small user-facing changes that are backward-compatible and
+  do not introduce new functionality.
+
+  This includes bug fixes or other internal changes that do not affect the API such
+  as refactoring code, improving performance, or updating user documentation.
+
+* **`internal-change`**
+
+  Use when the PR includes changes that are NOT user facing and will NOT require a
+  release.
+
+  This includes updates to developer documentation, comments, GitHub Actions, minor
+  refactorings, and fixing Rubocop offenses.
+
+### Releasing
+
+To release a new version, first determine the proper semver increment based on the
+PRs included in the release.
+
+Then in the root directory of this project with the `main` branch checked out, run
+the following command:
+
+```shell
+create-github-release {major|minor|patch}
+```
+
+Follow the directions given by the `create-github-release` to publish the new version
+of the gem.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT
+License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
This PR makes the following changes:

* Add a job to the Continuous Integration workflow that verifies that the PR has a semver label: `major-change`, `minor-change`, `patch-change`, or `internal-change`.
* The job and the workflow should fail if the label is missing.
* The job should be skipped if the workflow was not triggered by a PR.

The meaning of each label is:

* **`major-change`**

  Use when the PR includes incompatible API or functional changes.

  This typically occurs when the changes introduced could break existing code that
  depends on this gem. For example, removing a public method, changing a method's
  signature, or altering the expected behavior of a method in a way that would
  require changes in the dependent code.

* **`minor-change`**

  Use when the PR adds functionality in a backward-compatible manner.

  This includes adding new features, enhancements, or deprecating existing features
  as long as the deprecation itself doesn't break compatibility.

  It's also common to include substantial improvements or optimizations in this
  category, as long as they don't alter the expected behavior of the existing API.

* **`patch-change`**

  Use when the PR includes small user-facing changes that are backward-compatible and
  do not introduce new functionality.

  This includes bug fixes or other internal changes that do not affect the API such
  as refactoring code, improving performance, or updating user documentation.

* **`internal-change`**

  Use when the PR includes changes that are NOT user facing and will NOT require a
  release.

  This includes updates to developer documentation, comments, GitHub Actions, minor
  refactorings, and fixing Rubocop offenses.