### PR TITLE
Instruct Rubocop that dev deps go in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*_spec.rb"
     - "*.gemspec"
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'solargraph', '~> 0.47'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.5'


### PR DESCRIPTION
A new Rubocop cop wants all development dependencies to go into the Gemfile, but I like to keep them in the gemspec.