### PR TITLE
Separate semver PR label check into its own workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,18 +1,13 @@
 name: Continuous Integration
 
+# This is a workflow fix
+
 on:
   push:
     branches: [main]
 
   pull_request:
     branches: [main]
-
-    # The default triggers for pull requests are opened, synchronize, and reopened.
-    # Add labeled and unlabeled to the list of triggers so that the
-    # check_for_semver_pr_label job is run when a label is added or removed from a
-    # pull request.
-
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   build:
@@ -49,18 +44,6 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
-
-  check_for_semver_pr_label:
-    name: Check that a semver label is present on the PR
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check that a semver label is present on the PR
-        if: github.event_name == 'pull_request'
-        uses: docker://agilepathway/pull-request-label-checker:latest
-        with:
-          one_of: major-change,minor-change,patch-change,internal-change
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   coverage:
     name: Report test coverage to CodeClimate

--- a/.github/workflows/semver_pr_label.yml
+++ b/.github/workflows/semver_pr_label.yml
@@ -1,0 +1,25 @@
+name: Semver PR Label
+
+on:
+  pull_request:
+    branches: [main]
+
+    # The default triggers for pull requests are opened, synchronize, and reopened.
+    # Add labeled and unlabeled to the list of triggers so that the
+    # semver_pr_label job is run when a label is added or removed from a
+    # pull request.
+
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  semver_pr_label:
+    name: Semver PR Label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check that a semver label is present on the PR
+        if: github.event_name == 'pull_request'
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major-change,minor-change,patch-change,internal-change
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separate semver PR label check into its own workflow

Putting this into the Continuous Integration workflow caused the workflow to trigger two times when a PR is created because creating the PR and applying the first label seem to be BOTH triggered. This was causing 9 build jobs to run twice unnecessarily.

This change separates out the semver PR label check into its own workflow. This semver PR label check workflow is still triggered twice when a PR is created with an initial label. At least the Continuous Integration workflow is not triggered twice.