### PR TITLE
An invalid timeout value should raise an ArgumentError

### DIFF
--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -2,6 +2,7 @@
 
 require 'forwardable'
 require 'ostruct'
+require 'pp'
 
 module ProcessExecuter
   # Validate ProcessExecuter::Executer#spawn options and return Process.spawn options
@@ -87,6 +88,7 @@ module ProcessExecuter
     def initialize(**options)
       assert_no_unknown_options(options)
       @options = DEFAULTS.merge(options)
+      assert_timeout_is_valid
     end
 
     # Returns the options to be passed to Process.spawn
@@ -128,6 +130,24 @@ module ProcessExecuter
     def assert_no_unknown_options(options)
       unknown_options = options.keys.reject { |key| valid_option?(key) }
       raise ArgumentError, "Unknown options: #{unknown_options.join(', ')}" unless unknown_options.empty?
+    end
+
+    # Raise an error if timeout is not a real non-negative number
+    # @return [void]
+    # @raise [ArgumentError] if timeout is not a real non-negative number
+    # @api private
+    def assert_timeout_is_valid
+      return if @options[:timeout].nil?
+      return if @options[:timeout].is_a?(Numeric) && @options[:timeout].real? && !@options[:timeout].negative?
+
+      raise ArgumentError, invalid_timeout_message
+    end
+
+    # The message to be used when raising an error for an invalid timeout
+    # @return [String]
+    # @api private
+    def invalid_timeout_message
+      "timeout must be nil or a real non-negative number but was #{options[:timeout].pretty_inspect}"
     end
 
     # Determine if the given option is a valid option

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/main-branch/process_executer'
-  spec.metadata['changelog_uri'] = 'https://rubydoc.info/gems/process_executer/file/CHANGELOG.md'
-  spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/process_executer/#{ProcessExecuter::VERSION}"
+  spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
+  spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/process_executer/options_spec.rb
+++ b/spec/process_executer/options_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ProcessExecuter::Options do
       umask: double('umask'),
       close_others: double('close_others'),
       chdir: double('chdir'),
-      timeout: double('timeout')
+      timeout: 0
     }
     # :nocov:
   end

--- a/spec/process_executer_spec.rb
+++ b/spec/process_executer_spec.rb
@@ -4,6 +4,48 @@ RSpec.describe ProcessExecuter do
   describe '.spawn' do
     subject { ProcessExecuter.spawn(*command, **options) }
 
+    context 'when :timeout is specified' do
+      context 'when :timeout is a String' do
+        let(:command) { %w[echo hello] }
+        let(:options) { { timeout: 'a string' } }
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error(ArgumentError, /timeout/)
+        end
+      end
+
+      context 'when :timeout is a Complex' do
+        let(:command) { %w[echo hello] }
+        let(:options) { { timeout: Complex(3, 4) } }
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error(ArgumentError, /timeout/)
+        end
+      end
+
+      context 'when :timeout is nil' do
+        let(:command) { %w[echo hello] }
+        let(:options) { { timeout: nil } }
+        it 'should NOT raise an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when :timeout an Integer' do
+        let(:command) { %w[echo hello] }
+        let(:options) { { timeout: Integer(1) } }
+        it 'should NOT raise an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when :timeout a Float' do
+        let(:command) { %w[echo hello] }
+        let(:options) { { timeout: Float(1.0) } }
+        it 'should NOT raise an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+    end
+
     context 'for a command that does not time out' do
       let(:command) { %w[false] }
       let(:options) { {} }


### PR DESCRIPTION
`ProcessExecuter.spawn(..., timeout: value)` should raise an ArgumentError if the value is not nil or a real non-negative number.