### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the process_executer gem will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.2 (2024-02-01)
+
+[Full Changelog](https://github.com/main-branch/process_executer/compare/v1.0.1..v1.0.2)
+
+Changes since v1.0.1:
+
+* 76ffb91 An invalid timeout value should raise an ArgumentError (#41)
+* b748819 Release v1.0.1 (#40)
+
 ## v1.0.1 (2024-01-04)
 
 [Full Changelog](https://github.com/main-branch/process_executer/compare/v1.0.0..v1.0.1)

--- a/lib/process_executer/version.rb
+++ b/lib/process_executer/version.rb
@@ -2,5 +2,5 @@
 
 module ProcessExecuter
   # The current Gem version
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
# Release PR

## v1.0.2 (2024-02-01)

[Full Changelog](https://github.com/main-branch/process_executer/compare/v1.0.1..v1.0.2)

Changes since v1.0.1:

* 76ffb91 An invalid timeout value should raise an ArgumentError (#41)
* b748819 Release v1.0.1 (#40)
