### PR TITLE
Integrate simplecov-rspec for code coverage in CI builds

### DIFF
--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'semverify', '~> 0.3'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'simplecov-rspec', '~> 0.2'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.6'

--- a/spec/process_executer_spec.rb
+++ b/spec/process_executer_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe ProcessExecuter do
       it { is_expected.to have_attributes(timeout?: false, exitstatus: 1) }
     end
 
+    def windows?
+      !!(RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/)
+    rescue StandardError
+      # :nocov:
+      false
+      # :nocov:
+    end
+
     context 'for a command that times out' do
       let(:command) { %w[sleep 1] }
       let(:options) { { timeout: 0.01 } }
@@ -68,8 +76,7 @@ RSpec.describe ProcessExecuter do
         expect(end_time - start_time).to be < 0.1
 
         # :nocov:
-        # rubocop:disable Style/RescueModifier
-        if (WINDOWS = (RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/) rescue false)
+        if windows?
           # On windows, the status of a process killed with SIGKILL will indicate
           # that the process exited normally with exitstatus 0.
           expect(subject).to have_attributes(exited?: true, exitstatus: 0, timeout?: true)
@@ -78,7 +85,6 @@ RSpec.describe ProcessExecuter do
           # that the process terminated because of the uncaught signal
           expect(subject).to have_attributes(signaled?: true, termsig: 9, timeout?: true)
         end
-        # rubocop:enable Style/RescueModifier
         # :nocov:
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,73 +12,19 @@ RSpec.configure do |config|
   end
 end
 
-# Setup simplecov
-
 require 'simplecov'
 require 'simplecov-lcov'
-require 'json'
+require 'simplecov-rspec'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
-
-# Report if the test coverage was below the configured threshold
-#
-# The threshold is configured by setting the `test_coverage_threshold` variable
-# in this file.
-#
-# Example:
-#
-# ```Ruby
-# test_coverage_threshold = 100
-# ```
-#
-# Coverage below the threshold will cause the rspec run to fail unless the
-# `COV_NO_FAIL` environment variable is set to TRUE.
-#
-# ```Shell
-# COV_NO_FAIL=TRUE rspec
-# ```
-#
-# Example of running the tests in an infinite loop writing failures to `fail.txt`:
-#
-# ```Shell
-# while true; do COV_NO_FAIL=TRUE rspec >> fail.txt; done
-# ````
-#
-# The lines missing coverage will be displayed if the `COV_SHOW_UNCOVERED`
-# environment variable is set to TRUE.
-#
-# ```Shell
-# COV_SHOW_UNCOVERED=TRUE rspec
-# ```
-#
-test_coverage_threshold = 100
-
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  # rubocop:disable Style/StderrPuts
-  if SimpleCov.result.covered_percent < test_coverage_threshold
-    $stderr.puts
-    $stderr.print 'FAIL: ' if fail_on_low_coverage?
-    $stderr.puts "RSpec Test coverage fell below #{test_coverage_threshold}%"
-
-    if show_lines_not_covered?
-      $stderr.puts "\nThe following lines were not covered by tests:\n"
-      SimpleCov.result.files.each do |source_file| # SimpleCov::SourceFile
-        source_file.missed_lines.each do |line| # SimpleCov::SourceFile::Line
-          $stderr.puts "  .#{source_file.project_filename}:#{line.number}"
-        end
-      end
-    end
-
-    $stderr.puts
-
-    exit 1 if fail_on_low_coverage?
-  end
-  # rubocop:enable Style/StderrPuts
+if ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
 end
 
-SimpleCov.start
+SimpleCov::RSpec.start
 
-# Make sure to require your project AFTER SimpleCov.start
+# Make sure to require your project AFTER starting SimpleCov
 #
 require 'process_executer'


### PR DESCRIPTION
Move the code that ensures the CI build maintains code coverage threshold to its own gem (simplecov-rspec).