### PR TITLE
Move CI builds using experimental Rubies to a different workflow

### DIFF
--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -20,15 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-head", "truffleruby-head"]
-        operating-system: [ubuntu-latest]
         include:
-          - # Run minimal Ruby version supported on windows-latest
-            ruby: 3.0
-            operating-system: windows-latest
+          - # Run head version of Ruby on ubuntu-latest
+            ruby: head
+            operating-system: ubuntu-latest
 
-          - # Run maximal Ruby version supported on windows-latest
-            ruby: 3.3
+          - # Experimental build for jruby on windows
+            ruby: jruby-head
             operating-system: windows-latest
 
     env:
@@ -48,24 +46,24 @@ jobs:
       - name: Run rake
         run: bundle exec rake
 
-  experimental:
-    name: Experimental builds
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Only run if on main branch
+        experimental:
+          name: Experimental builds
+          needs: [build]
+          runs-on: ubuntu-latest
+          if: github.ref == 'refs/heads/main'  # Only run if on main branch
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh -y
+            - name: Install GitHub CLI
+              run: sudo apt-get install gh -y
 
-      - name: Authenticate with GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+            - name: Authenticate with GitHub CLI
+              run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
-      - name: Trigger Experimental Workflow
-        run: gh workflow run experimental_continuous_integration.yml
+            - name: Trigger Experimental Workflow
+              run: gh workflow run experimental_continuous_integration.yml
 
   coverage:
     name: Report test coverage to CodeClimate


### PR DESCRIPTION
This pull request moves the CI build using experimental Rubies to a separate workflow. The previous workflow included experimental builds, but now the experimental builds are triggered separately using a repository dispatch event. This change ensures that the experimental builds can be triggered independently and allows for better organization of the CI workflows.