### PR TITLE
Rename the experimental build workflow

### DIFF
--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -1,9 +1,7 @@
-name: Continuous Integration
-
-# This is a workflow fix
+name: Experimental Rubies
 
 on:
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
Rename the experimental builds workflow to "Experimental Rubies" to distinguish it from from the "Continuous Integration" workflow.