### PR TITLE
Simplify how the experimental ruby builds are triggered

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,25 +48,6 @@ jobs:
       - name: Run rake
         run: bundle exec rake
 
-  experimental:
-    name: Experimental builds
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Only run if on main branch
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh -y
-
-      - name: Authenticate with GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
-      - name: Trigger Experimental Workflow
-        run: gh workflow run experimental_continuous_integration.yml
-
   coverage:
     name: Report test coverage to CodeClimate
     needs: [ build ]

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,7 +1,10 @@
-name: Experimental Rubies
+name: Experimental Ruby Builds
 
 on:
-  workflow_dispatch
+  push:
+    branches: [main]
+
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request simplifies the process of triggering experimental ruby builds.

The unnecessary steps for authenticating with GitHub CLI and triggering the experimental workflow have been removed. Now, the experimental builds will be triggered automatically when pushing to the main branch or manually through the workflow dispatch event.