### PR TITLE
Integrate simplecov-rspec into the project

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,9 @@ jobs:
           - ruby: "3.1"
             operating-system: windows-latest
 
+    env:
+      JRUBY_OPTS: --debug
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +50,9 @@ jobs:
 
     needs: [build]
     runs-on: ubuntu-latest
+
+    env:
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -40,7 +40,6 @@ jobs:
             operating-system: windows-latest
 
     env:
-      JAVA_OPTS: -Djdk.io.File.enableADS=true
       JRUBY_OPTS: --debug
 
     steps:

--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'semverify', '~> 0.3'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'simplecov-rspec', '~> 0.2'
+  spec.add_development_dependency 'simplecov-rspec', '~> 0.3'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,18 +12,22 @@ RSpec.configure do |config|
   end
 end
 
+# SimpleCov configuration
+#
 require 'simplecov'
 require 'simplecov-lcov'
 require 'simplecov-rspec'
 
-if ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+
+if ci_build?
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::LcovFormatter
   ]
 end
 
-SimpleCov::RSpec.start
+SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 
 # Make sure to require your project AFTER starting SimpleCov
 #


### PR DESCRIPTION
This pull request integrates the `simplecov-rspec` gem into the project. It updates the gem version to `0.3` and includes the necessary configuration for SimpleCov. Additionally, it adds the `list_uncovered_lines` option to SimpleCov's RSpec configuration for CI builds.