### PR TITLE
Set JRuby --debug option when running tests in GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,11 @@ on:
 
   workflow_dispatch:
 
+env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
+  JRUBY_OPTS: --debug
+
 # Supported platforms / Ruby versions:
 #  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
 #  - Windows: MRI (3.1)
@@ -29,9 +34,6 @@ jobs:
           - ruby: "3.1"
             operating-system: windows-latest
 
-    env:
-      JRUBY_OPTS: --debug
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,9 +52,6 @@ jobs:
 
     needs: [build]
     runs-on: ubuntu-latest
-
-    env:
-      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -6,6 +6,11 @@ on:
 
   workflow_dispatch:
 
+env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
+  JRUBY_OPTS: --debug
+
 # Experimental platforms / Ruby versions:
 #  - Ubuntu: MRI (head), JRuby (head), TruffleRuby (head)
 #  - Windows: MRI (head), JRuby (9.4), JRuby (head)
@@ -38,9 +43,6 @@ jobs:
 
           - ruby: jruby-head
             operating-system: windows-latest
-
-    env:
-      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout


### PR DESCRIPTION
SimpleCov suggests using the `--debug` option in to ensure that code coverage is reported correctly.

When SimpleCov is run in JRuby, it gives the warning:

```
Coverage may be inaccurate; set the "--debug" command line option, or do 
JRUBY_OPTS="--debug" or set the "debug.fullTrace=true" option in your .jrubyrc
```

This PR adds the JRUBY_OPTS environment variable in all GitHub Actions workflows at the global level.