### PR TITLE
Remove unused require for 'forwardable' and 'ostruct'

### DIFF
--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-require 'ostruct'
 require 'pp'
 
 module ProcessExecuter


### PR DESCRIPTION
Fixes #65

When running on Ruby 3.4 pre-release version, the following warning is output:

```
/home/runner/work/process_executer/process_executer/lib/process_executer.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

This can be seen in the "Run Rake" step of [the "Ruby head on ubuntu-latest" job](https://github.com/main-branch/process_executer/actions/runs/10916458057/job/30297928451).


These requires in options.rb were not actually needed.