### PR TITLE
Remove unused require for 'forwardable' and 'ostruct' (for branch v1.x)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,10 +4,10 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [main]
+    branches: [main, v1.x]
 
   pull_request:
-    branches: [main]
+    branches: [main, v1.x]
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/semver_pr_label.yml
+++ b/.github/workflows/semver_pr_label.yml
@@ -2,7 +2,7 @@ name: Semver PR Label
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1.x]
 
     # The default triggers for pull requests are opened, synchronize, and reopened.
     # Add labeled and unlabeled to the list of triggers so that the

--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-require 'ostruct'
 require 'pp'
 
 module ProcessExecuter

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
   describe '#close' do
     it 'should kill the thread' do
       monitored_pipe.close
+      sleep(0.25) # Give the thread time to die
       expect(monitored_pipe.thread.alive?).to eq(false)
     end
 


### PR DESCRIPTION
Fixes #65 for the 1.x release line.

When running on Ruby 3.4 pre-release version, the following warning is output:

```
/home/runner/work/process_executer/process_executer/lib/process_executer.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
This can be seen in the "Run Rake" step of the "Ruby head on ubuntu-latest" job.
```

These requires in options.rb were not actually needed.