### PR TITLE
Re-add require for 'forwardable' (v1.x)

### DIFF
--- a/lib/process_executer/status.rb
+++ b/lib/process_executer/status.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'delegate'
+require 'forwardable'
 
 module ProcessExecuter
   # A simple delegator for Process::Status that adds a `timeout?` attribute


### PR DESCRIPTION
Fixes #71 for v1.x release line

PR #68 removed a needed require for 'forwardable'. This PR re-adds this require in the file it is really needed in.