### PR TITLE
Fix flakey test that checks for thread to die

### DIFF
--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -27,9 +27,21 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
   end
 
   describe '#close' do
-    it 'should kill the thread' do
+    it 'should eventually kill the thread' do
       monitored_pipe.close
-      expect(monitored_pipe.thread.alive?).to eq(false)
+
+      # Give the thread time to die (up to 1 second)
+      thread_dead = false
+      10.times do
+        # :nocov:
+        thread_dead = !monitored_pipe.thread.alive?
+        break if thread_dead
+
+        sleep(0.1)
+        # :nocov:
+      end
+
+      expect(thread_dead).to eq(true)
     end
 
     it 'should set the state to closed' do


### PR DESCRIPTION
A MonitoredPipe creates a thread to read data written to the pipe and rely that data to one or more writers passed to `#initialize`

`MonitoredPipe#close` kills the thread but does not wait for the thread to fully die.

The test for `MonitoredPipe#close` checks to make sure the thread has been killed. However, the test sometimes fails (particularly in JRuby) because the thread isn't given enough time to die.

This PR makes the test wait up to 1 sec for the thread to die.