### PR TITLE
Remove failing build for JRuby on Windows (v1.x)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,13 +38,6 @@ jobs:
             # the build failing on "ruby: head".
             # experimental: Yes
 
-          - # Experimental build for jruby on windows
-            ruby: jruby-head
-            operating-system: windows-latest
-            # This gem does not support jruby on windows yet
-            # Remove this `experimental` flag when this build succeeds.
-            experimental: Yes
-
     env:
       JAVA_OPTS: -Djdk.io.File.enableADS=true
       JRUBY_OPTS: --debug


### PR DESCRIPTION
For the v1.x release line, remove the failing build for JRuby on Windows. This build is failing because there is a bug in JRuby (see jruby/jruby#7515).

I would consider adding this build back if the above issue is fixed.