### PR TITLE
Allow the `#spawn` method to accept file descriptors for redirection

### DIFF
--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 RSpec.describe ProcessExecuter::MonitoredPipe do
   let(:monitored_pipe) { described_class.new(*writers) }
-  let(:output) { StringIO.new }
-  let(:writers) { [output] }
+  let(:output_writer) { StringIO.new }
+  let(:writers) { [output_writer] }
 
   describe '#initialize' do
     after { monitored_pipe.close }
@@ -37,7 +39,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         thread_dead = !monitored_pipe.thread.alive?
         break if thread_dead
 
-        sleep(0.1)
+        sleep(0.01)
         # :nocov:
       end
 
@@ -78,60 +80,132 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         monitored_pipe.write(' ')
         monitored_pipe.write('world')
         monitored_pipe.close
-        expect(output.string).to eq('hello world')
+        expect(output_writer.string).to eq('hello world')
       end
     end
 
     context 'with multiple writers' do
-      let(:output1) { StringIO.new }
-      let(:output2) { StringIO.new }
-      let(:writers) { [output1, output2] }
+      let(:output_writer1) { StringIO.new }
+      let(:output_writer2) { StringIO.new }
+      let(:writers) { [output_writer1, output_writer2] }
       it 'should write to the writers' do
         monitored_pipe.write('hello')
         monitored_pipe.write(' ')
         monitored_pipe.write('world')
         monitored_pipe.close
-        expect(output1.string).to eq('hello world')
-        expect(output2.string).to eq('hello world')
+        expect(output_writer1.string).to eq('hello world')
+        expect(output_writer2.string).to eq('hello world')
       end
     end
 
-    # Make sure that all code paths are covered by the tests
+    context 'with a file descriptor to an open file' do
+      it 'should write to the file descriptor' do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, 'output.txt')
+          file = File.open(path, 'w')
+          pid = Process.spawn('echo hello', out: file.fileno)
+          Process.wait(pid)
+          file.close
+          expect(File.read(path)).to eq("hello\n")
+        end
+      end
+    end
+
+    context 'with a file descriptor to an open file' do
+      let(:writers) { [@file.fileno] }
+
+      it 'should write to the file descriptor' do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, 'output.txt')
+          @file = File.open(path, 'w')
+          monitored_pipe.write('hello')
+          monitored_pipe.write(' ')
+          monitored_pipe.write('world')
+          sleep 0.5
+          monitored_pipe.close
+          @file.close
+          expect(File.read(path)).to eq('hello world')
+        end
+      end
+    end
+
+    context 'with :out' do
+      let(:writers) { [:out] }
+
+      it 'should write to STDOUT' do
+        expect do
+          monitored_pipe.write("hello world\n")
+          sleep 0.01
+        end.to output("hello world\n").to_stdout
+      end
+    end
+
+    context 'with 1' do
+      let(:writers) { [1] }
+
+      it 'should write to STDOUT' do
+        expect do
+          monitored_pipe.write("hello world\n")
+          sleep 0.01
+        end.to output("hello world\n").to_stdout
+      end
+    end
+
+    context 'with :err' do
+      let(:writers) { [:err] }
+
+      it 'should write to STDERR' do
+        expect do
+          monitored_pipe.write("hello world\n")
+          sleep 0.01
+        end.to output("hello world\n").to_stderr
+      end
+    end
+
+    context 'with 2' do
+      let(:writers) { [2] }
+
+      it 'should write to STDERR' do
+        expect do
+          monitored_pipe.write("hello world\n")
+          sleep 0.01
+        end.to output("hello world\n").to_stderr
+      end
+    end
+
     context 'when there is time between the writes to the pipe' do
       it 'should write to the writer' do
         monitored_pipe.write('hello')
-        sleep 0.1
+        sleep 0.01
         monitored_pipe.write(' ')
-        sleep 0.1
+        sleep 0.01
         monitored_pipe.write('world')
+        sleep 0.01
         monitored_pipe.close
-        expect(output.string).to eq('hello world')
+        expect(output_writer.string).to eq('hello world')
       end
     end
 
-    # Make sure that all code paths are covered by the tests
     context 'when there is a delay before the first write to the pipe' do
       it 'should write to the writer' do
         sleep 0.1
         monitored_pipe.write('hello')
         monitored_pipe.write(' ')
-        sleep 0.1
         monitored_pipe.write('world')
+        sleep 0.01
         monitored_pipe.close
-        expect(output.string).to eq('hello world')
+        expect(output_writer.string).to eq('hello world')
       end
     end
 
-    # Make sure that all code paths are covered by the tests
     context 'when there is a delay after the last write to the pipe' do
       it 'should write to the writer' do
         monitored_pipe.write('hello')
         monitored_pipe.write(' ')
-        sleep 0.1
         monitored_pipe.write('world')
-        sleep 0.2
+        sleep 0.1
         monitored_pipe.close
-        expect(output.string).to eq('hello world')
+        expect(output_writer.string).to eq('hello world')
       end
     end
 
@@ -140,41 +214,41 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         data = 'h' * 50_000_000
         monitored_pipe.write(data)
         monitored_pipe.close
-        expect(output.string.size).to eq(data.size)
+        expect(output_writer.string.size).to eq(data.size)
       end
     end
 
     context 'when a writer raises an exception' do
-      let(:output) { double('output') }
+      let(:output_writer) { double('output') }
       before do
-        expect(output).to receive(:write).with('hello').and_raise(
+        expect(output_writer).to receive(:write).with('hello').and_raise(
           Encoding::UndefinedConversionError, 'UTF-8 conversion error'
         )
       end
-      let(:writers) { [output] }
+      let(:writers) { [output_writer] }
 
       it 'should eventually kill the monitoring thread' do
         monitored_pipe.write('hello')
-        sleep(0.1)
+        sleep(0.01)
         expect(monitored_pipe.thread.alive?).to eq(false)
       end
 
       it 'should eventually set the state to :closed' do
         monitored_pipe.write('hello')
-        sleep(0.1)
+        sleep(0.01)
         expect(monitored_pipe.state).to eq(:closed)
       end
 
       it 'should eventually save the exception raised to #exception' do
         monitored_pipe.write('hello')
-        sleep(0.1)
+        sleep(0.01)
         expect(monitored_pipe.exception).to be_a(Encoding::UndefinedConversionError)
         expect(monitored_pipe.exception.message).to eq('UTF-8 conversion error')
       end
 
       it 'should raise an exception if #write is called after the pipe is closed' do
         monitored_pipe.write('hello')
-        sleep(0.1)
+        sleep(0.01)
         expect { monitored_pipe.write('world') }.to raise_error(IOError, 'closed stream')
       end
     end

--- a/spec/process_executer/options_spec.rb
+++ b/spec/process_executer/options_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ProcessExecuter::Options do
     context 'when all options are given' do
       let(:options_hash) { all_options_hash }
       let(:expected_spawn_options) do
-        all_options_hash.select { |key, _| ProcessExecuter::Options::SPAWN_OPTIONS.include?(key) }
+        all_options_hash.slice(*ProcessExecuter::Options::SPAWN_OPTIONS)
       end
       it { is_expected.to eq(expected_spawn_options) }
     end

--- a/spec/process_executer_spec.rb
+++ b/spec/process_executer_spec.rb
@@ -23,23 +23,29 @@ RSpec.describe ProcessExecuter do
 
       context 'when :timeout is nil' do
         let(:command) { %w[echo hello] }
-        let(:options) { { timeout: nil } }
+        let(:output_writer) { StringIO.new }
+        let(:output_pipe) { ProcessExecuter::MonitoredPipe.new(output_writer) }
+        let(:options) { { out: output_pipe, timeout: nil } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
         end
       end
 
-      context 'when :timeout an Integer' do
+      context 'when :timeout is an Integer' do
         let(:command) { %w[echo hello] }
-        let(:options) { { timeout: Integer(1) } }
+        let(:output_writer) { StringIO.new }
+        let(:output_pipe) { ProcessExecuter::MonitoredPipe.new(output_writer) }
+        let(:options) { { out: output_pipe, timeout: Integer(1) } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
         end
       end
 
-      context 'when :timeout a Float' do
+      context 'when :timeout is a Float' do
         let(:command) { %w[echo hello] }
-        let(:options) { { timeout: Float(1.0) } }
+        let(:output_writer) { StringIO.new }
+        let(:output_pipe) { ProcessExecuter::MonitoredPipe.new(output_writer) }
+        let(:options) { { out: output_pipe, timeout: Float(1.0) } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
         end


### PR DESCRIPTION
This change enables `ProcessExecuter.spawn`  to accept file descriptors (either an integer or one of the special symbols `:out` or `:err`) as redirection destinations.

This will allow `ProcessExecuter.spawn` to be a drop-in replacement for `Process.spawn`.