### PR TITLE
chore: do not fail the CI build for low coverage on JRuby and TruffleRuby

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,11 +28,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", "jruby-9.4", "truffleruby-24"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         operating-system: [ubuntu-latest]
         include:
           - ruby: "3.1"
             operating-system: windows-latest
+          - ruby: "jruby-9.4"
+            operating-system: ubuntu-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
+          - ruby: "truffleruby-24"
+            operating-system: ubuntu-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -34,15 +34,19 @@ jobs:
 
           - ruby: truffleruby-head
             operating-system: ubuntu-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
 
           - ruby: jruby-9.4
             operating-system: windows-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
 
           - ruby: jruby-head
             operating-system: ubuntu-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
 
           - ruby: jruby-head
             operating-system: windows-latest
+            env: { FAIL_ON_LOW_COVERAGE: FALSE }
 
     steps:
       - name: Checkout

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -11,12 +11,9 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
     after { monitored_pipe.close }
 
     it 'should create a new monitored pipe' do
-      # SimpleCov in JRuby reports the following line as not covered even though it is
-      # :nocov:
       expect(monitored_pipe).to have_attributes(
         thread: Thread, writers:, pipe_reader: IO, pipe_writer: IO, chunk_size: 100_000
       )
-      # :nocov:
     end
 
     it 'should start a thread to monitor the pipe' do
@@ -35,10 +32,10 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # Give the thread time to die (up to 1 second)
       thread_dead = false
       10.times do
-        # :nocov:
         thread_dead = !monitored_pipe.thread.alive?
         break if thread_dead
 
+        # :nocov: this code is not guaranteed to be run
         sleep(0.01)
         # :nocov:
       end

--- a/spec/process_executer/options_spec.rb
+++ b/spec/process_executer/options_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe ProcessExecuter::Options do
   let(:options) { ProcessExecuter::Options.new(**options_hash) }
 
   let(:all_options_hash) do
-    # :nocov:
-    # JRuby does not count the following as covered even though it is
     {
       in: double('in'),
       out: double('out'),
@@ -26,7 +24,6 @@ RSpec.describe ProcessExecuter::Options do
       timeout_after: 0,
       raise_errors: true
     }
-    # :nocov:
   end
 
   describe '#initialize' do

--- a/spec/process_executer_run_spec.rb
+++ b/spec/process_executer_run_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ProcessExecuter do
 
         it 'is expected to have the expected error message' do
           pid = subject.result.pid
-          # :nocov:
+          # :nocov: execution of this code is platform dependent
           expected_message =
             if RUBY_ENGINE == 'jruby'
               %(["sleep 1"], status: pid #{pid} KILL (signal 9) timed out after 0.01s, stderr: "")
@@ -155,7 +155,7 @@ RSpec.describe ProcessExecuter do
         it 'is expected to have the expected error message' do
           pid = subject.result.pid
 
-          # :nocov:
+          # :nocov: execution of this code is platform dependent
           expected_message =
             if RUBY_ENGINE == 'jruby'
               %(#{command.inspect}, status: pid #{pid} KILL (signal 9), stderr: "")
@@ -420,7 +420,7 @@ RSpec.describe ProcessExecuter do
           it 'is expected to log the command and its status' do
             subject
 
-            # :nocov:
+            # :nocov: execution of this code is platform dependent
             expected_message =
               if RUBY_ENGINE == 'jruby'
                 /INFO -- : \[.*?\] exited with status pid \d+ KILL \(signal 9\) timed out after 0.01s$/

--- a/spec/process_executer_spawn_and_wait_spec.rb
+++ b/spec/process_executer_spawn_and_wait_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ProcessExecuter do
     def windows?
       !!(RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/)
     rescue StandardError
-      # :nocov:
+      # :nocov: this code is not guaranteed to be executed
       false
       # :nocov:
     end
@@ -85,7 +85,7 @@ RSpec.describe ProcessExecuter do
         # The process should have been killed very soon after 0.01 seconds (before 1 second)
         expect(end_time - start_time).to be < 0.1
 
-        # :nocov:
+        # :nocov: execution of this code is platform dependent
         if windows?
           # On windows, the status of a process killed with SIGKILL will indicate
           # that the process exited normally with exitstatus 0.


### PR DESCRIPTION
There are many cases where JRuby and TruffleRuby do not catch lines that were covered when they actually were covered.

Instead, coverage will only be enforced for MRI Ruby on both Linux and Windows.

Tests will still be run on JRuby and TruffleRuby and coverage will be reported, but low coverage will NOT fail the build.