### PR TITLE
feat: add logging to ProcessExecuter.spawn_and_wait

### DIFF
--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -267,7 +267,8 @@ module ProcessExecuter
       # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
       [
         *super,
-        OptionDefinition.new(:timeout_after, default: nil, validator: method(:validate_timeout_after))
+        OptionDefinition.new(:timeout_after, default: nil, validator: method(:validate_timeout_after)),
+        OptionDefinition.new(:logger, default: Logger.new(nil), validator: method(:validate_logger))
       ].freeze
       # :nocov:
     end
@@ -284,6 +285,20 @@ module ProcessExecuter
       raise(
         ArgumentError,
         "timeout_after must be nil or a non-negative real number but was #{timeout_after.inspect}"
+      )
+      # :nocov:
+    end
+
+    # Validate the logger option value
+    # @return [String, nil] the error message if the value is not valid
+    # @api private
+    def validate_logger
+      return if logger.respond_to?(:info) && logger.respond_to?(:debug)
+
+      # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
+      raise(
+        ArgumentError,
+        "logger must respond to #info and #debug but was #{logger.inspect}"
       )
       # :nocov:
     end
@@ -305,8 +320,7 @@ module ProcessExecuter
       [
         *super,
         OptionDefinition.new(:merge, default: false, validator: method(:validate_merge)),
-        OptionDefinition.new(:raise_errors, default: true, validator: method(:validate_raise_errors)),
-        OptionDefinition.new(:logger, default: Logger.new(nil), validator: method(:validate_logger))
+        OptionDefinition.new(:raise_errors, default: true, validator: method(:validate_raise_errors))
       ].freeze
     end
     # :nocov:
@@ -335,20 +349,6 @@ module ProcessExecuter
       raise(
         ArgumentError,
         "merge must be true or false but was #{merge.inspect}"
-      )
-      # :nocov:
-    end
-
-    # Validate the logger option value
-    # @return [String, nil] the error message if the value is not valid
-    # @api private
-    def validate_logger
-      return if logger.respond_to?(:info) && logger.respond_to?(:debug)
-
-      # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
-      raise(
-        ArgumentError,
-        "logger must respond to #info and #debug but was #{logger.inspect}"
       )
       # :nocov:
     end

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -101,31 +101,11 @@ module ProcessExecuter
     # @api private
     #
     def process_result(result)
-      log_result(result)
+      return unless result.options.raise_errors
 
-      raise_errors(result) if result.options.raise_errors
-    end
-
-    # Raise an error if the command failed
-    # @return [void]
-    # @raise [ProcessExecuter::FailedError] If the command failed
-    # @raise [ProcessExecuter::SignaledError] If the command was signaled
-    # @raise [ProcessExecuter::TimeoutError] If the command times out
-    # @api private
-    def raise_errors(result)
       raise TimeoutError, result if result.timed_out?
       raise SignaledError, result if result.signaled?
       raise FailedError, result unless result.success?
-    end
-
-    # Log the result of running the command
-    # @param result [ProcessExecuter::Result] the result of the command including
-    #   the command, status, stdout, and stderr
-    # @return [void]
-    # @api private
-    def log_result(result)
-      result.options.logger.info { "#{result.command} exited with status #{result}" }
-      result.options.logger.debug { "stdout:\n#{result.stdout.inspect}\nstderr:\n#{result.stderr.inspect}" }
     end
 
     # Raise an error when there was exception while collecting the subprocess output

--- a/spec/process_executer/run_options_spec.rb
+++ b/spec/process_executer/run_options_spec.rb
@@ -31,48 +31,6 @@ RSpec.describe ProcessExecuter::RunOptions do
       end
     end
 
-    context 'when giving 10 for timeout_after' do
-      let(:options_hash) { { timeout_after: 10 } }
-
-      it 'should set timeout_after to 10' do
-        expect(subject.timeout_after).to eq(10)
-      end
-    end
-
-    context 'when giving 0 for timeout_after' do
-      let(:options_hash) { { timeout_after: 0 } }
-
-      it 'should set timeout_after to 0' do
-        expect(subject.timeout_after).to eq(0)
-      end
-    end
-
-    context 'when giving -1 for timeout_after' do
-      let(:options_hash) { { timeout_after: -1 } }
-
-      it 'should raise an error' do
-        expect { subject }.to(
-          raise_error(
-            ArgumentError,
-            'timeout_after must be nil or a non-negative real number but was -1'
-          )
-        )
-      end
-    end
-
-    context 'when given an invalid logger value' do
-      let(:options_hash) { { logger: 'invalid' } }
-
-      it 'should raise an error' do
-        expect { subject }.to(
-          raise_error(
-            ArgumentError,
-            'logger must respond to #info and #debug but was "invalid"'
-          )
-        )
-      end
-    end
-
     context 'when giving true for merge' do
       let(:options_hash) { { merge: true } }
 

--- a/spec/process_executer/spawn_and_wait_options_spec.rb
+++ b/spec/process_executer/spawn_and_wait_options_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe ProcessExecuter::SpawnAndWaitOptions do
           umask: :not_set,
           close_others: :not_set,
           chdir: :not_set,
-          timeout_after: nil
+          timeout_after: nil,
+          logger: be_a(Logger).and(satisfy { |logger| logger.instance_variable_get(:@logdev).nil? })
         )
       end
     end
@@ -51,6 +52,40 @@ RSpec.describe ProcessExecuter::SpawnAndWaitOptions do
           raise_error(
             ArgumentError,
             'timeout_after must be nil or a non-negative real number but was "invalid"'
+          )
+        )
+      end
+    end
+
+    context 'when giving 0 for timeout_after' do
+      let(:options_hash) { { timeout_after: 0 } }
+
+      it 'should set timeout_after to 0' do
+        expect(subject.timeout_after).to eq(0)
+      end
+    end
+
+    context 'when giving -1 for timeout_after' do
+      let(:options_hash) { { timeout_after: -1 } }
+
+      it 'should raise an error' do
+        expect { subject }.to(
+          raise_error(
+            ArgumentError,
+            'timeout_after must be nil or a non-negative real number but was -1'
+          )
+        )
+      end
+    end
+
+    context 'when given an invalid logger value' do
+      let(:options_hash) { { logger: 'invalid' } }
+
+      it 'should raise an error' do
+        expect { subject }.to(
+          raise_error(
+            ArgumentError,
+            'logger must respond to #info and #debug but was "invalid"'
           )
         )
       end

--- a/spec/process_executer_run_spec.rb
+++ b/spec/process_executer_run_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe ProcessExecuter do
 
     subject { result }
 
+    context 'when neither ":out" nor ":err" are given' do
+      let(:command) { ruby_command <<~COMMAND }
+        puts 'stdout output'
+        STDERR.puts 'stderr output'
+      COMMAND
+
+      it 'should capture stdout and stderr' do
+        aggregate_failures do
+          expect(subject.stdout.gsub("\r\n", "\n")).to eq("stdout output\n")
+          expect(subject.stderr.gsub("\r\n", "\n")).to eq("stderr output\n")
+        end
+      end
+    end
+
     context 'with a command that returns exitstatus 0' do
       let(:command) { ruby_command <<~COMMAND }
         puts 'stdout output'

--- a/spec/process_executer_spawn_and_wait_spec.rb
+++ b/spec/process_executer_spawn_and_wait_spec.rb
@@ -8,6 +8,41 @@ RSpec.describe ProcessExecuter do
   describe '.spawn_and_wait' do
     subject { ProcessExecuter.spawn_and_wait(*command, **options) }
 
+    context 'when :out and :err are given' do
+      context 'when :out and :err are both a StringIO wrapped in a MonitoredPipe' do
+        let(:command) { ruby_command <<~COMMAND }
+          puts 'stdout output'
+          STDERR.puts 'stderr output'
+        COMMAND
+
+        let(:options) { { out: @out_pipe, err: @err_pipe } }
+
+        it 'should capture stdout and stderr' do
+          @out_buffer = StringIO.new
+          @out_pipe = ProcessExecuter::MonitoredPipe.new(@out_buffer)
+          @err_buffer = StringIO.new
+          @err_pipe = ProcessExecuter::MonitoredPipe.new(@err_buffer)
+
+          begin
+            result = subject
+          ensure
+            # Alway close the pipes to ensure resourecs are released and
+            # final output is captured
+            @out_pipe.close
+            @err_pipe.close
+            # Always raise an exception if the pipe raised an exception
+            raise @out_pipe.exception if @out_pipe.exception
+            raise @err_pipe.exception if @err_pipe.exception
+          end
+
+          aggregate_failures do
+            expect(result.stdout.gsub("\r\n", "\n")).to eq("stdout output\n")
+            expect(result.stderr.gsub("\r\n", "\n")).to eq("stderr output\n")
+          end
+        end
+      end
+    end
+
     context 'when :timeout_after is specified' do
       context 'when :timeout_after is a String' do
         let(:command) { %w[echo hello] }
@@ -103,29 +138,14 @@ RSpec.describe ProcessExecuter do
       let(:logger) { Logger.new(log_buffer, level: log_level) }
       let(:log_buffer) { StringIO.new }
       let(:options) { { logger: logger } }
-      let(:options) { { out: @out_pipe, err: @err_pipe, logger:, timeout_after: } }
+      let(:options) { { logger:, timeout_after: } }
       let(:timeout_after) { nil }
-
-      before do
-        @out_buffer = StringIO.new
-        @out_pipe = ProcessExecuter::MonitoredPipe.new(@out_buffer)
-        @err_buffer = StringIO.new
-        @err_pipe = ProcessExecuter::MonitoredPipe.new(@err_buffer)
-      end
-
-      after do
-        # Alway close the pipes to ensure resourecs are released
-        @out_pipe.close
-        @err_pipe.close
-        # Always raise an exception if the pipe raised an exception
-        raise @out_pipe.exception if @out_pipe.exception
-        raise @err_pipe.exception if @err_pipe.exception
-      end
 
       context 'a command that returns exitstatus 0' do
         let(:command) { ruby_command <<~COMMAND }
           puts 'stdout output'
           STDERR.puts 'stderr output'
+          sleep 0.05
         COMMAND
 
         context 'when log level is WARN' do
@@ -147,12 +167,31 @@ RSpec.describe ProcessExecuter do
 
         context 'when log level is DEBUG' do
           let(:log_level) { Logger::DEBUG }
-          it 'is expected to log the command and its status AND the command stdout and stderr' do
-            subject
-            expect(log_buffer.string).to match(/INFO -- : \[.*?\] exited with status pid \d+ exit 0$/)
-            expect(log_buffer.string.gsub("\r\n", "\n").gsub('\r\n', '\n')).to(
-              match(/DEBUG -- : stdout:\n"stdout output\\n"\nstderr:\n"stderr output\\n"$/)
-            )
+          context 'when :out and :err are both a StringIO wrapped in a MonitoredPipe' do
+            let(:options) { { out: @out_pipe, err: @err_pipe, timeout_after:, logger: } }
+
+            it 'should log stdout and stderr' do
+              @out_buffer = StringIO.new
+              @out_pipe = ProcessExecuter::MonitoredPipe.new(@out_buffer)
+              @err_buffer = StringIO.new
+              @err_pipe = ProcessExecuter::MonitoredPipe.new(@err_buffer)
+
+              begin
+                subject
+              ensure
+                # Alway close the pipes to ensure resourecs are released and
+                # final output is captured
+                @out_pipe.close
+                @err_pipe.close
+                # Always raise an exception if the pipe raised an exception
+                raise @out_pipe.exception if @out_pipe.exception
+                raise @err_pipe.exception if @err_pipe.exception
+              end
+
+              expect(log_buffer.string.gsub("\r\n", "\n").gsub('\r\n', '\n')).to(
+                match(/DEBUG -- : stdout:\n"stdout output\\n"\nstderr:\n"stderr output\\n"$/)
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
Allow logging of the command that is being executed by the ProcessExecuter.spawn_and_wait method by passing in a logger object via the `logger:` option.

This moves the implementation of logging functionality from `.run` to `.spawn_and_wait` (which `.run` calls).