### PR TITLE
Allow SpawnOptions to accept Integer and IO redirection sources

### DIFF
--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -136,9 +136,9 @@ module ProcessExecuter
       # @raise [ArgumentError] if any invalid option values are found
       # @api private
       def validate_options
-        options.each_key do |option|
-          validator = allowed_options[option].validator
-          instance_exec(&validator.to_proc) if validator.is_a?(Method) || validator.is_a?(Proc)
+        options.each_key do |option_key|
+          validator = allowed_options[option_key]&.validator
+          instance_exec(&validator.to_proc) unless validator.nil?
         end
       end
 

--- a/spec/process_executer/options/base_spec.rb
+++ b/spec/process_executer/options/base_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProcessExecuter::Options::Base do
       end
     end
 
-    context 'when a multiple unknown option is given' do
+    context 'when multiple unknown options are given' do
       let(:options_hash) { { unknown1: true, unknown2: false } }
       it 'should raise an error' do
         expect { options }.to raise_error(ArgumentError, 'Unknown options: unknown1, unknown2')

--- a/spec/process_executer/options/spawn_options_spec.rb
+++ b/spec/process_executer/options/spawn_options_spec.rb
@@ -25,6 +25,62 @@ RSpec.describe ProcessExecuter::Options::SpawnOptions do
         )
       end
     end
+
+    context 'when an unknown option is given' do
+      it 'should raise an ArgumentError' do
+        expect { described_class.new(unknown: true) }.to raise_error(ArgumentError, 'Unknown option: unknown')
+      end
+    end
+  end
+
+  describe 'redirection options' do
+    context 'with an Integer source' do
+      let(:options_hash) { { 1 => File::NULL } }
+
+      it 'should allow the option' do
+        expect { options }.not_to raise_error
+      end
+
+      it 'should include the option in #spawn_options' do
+        expect(options.spawn_options).to include(**options_hash)
+      end
+    end
+
+    context 'with an IO source' do
+      let(:options_hash) { { $stdout => File::NULL } }
+
+      it 'should allow the option' do
+        expect { options }.not_to raise_error
+      end
+
+      it 'should include the option in #spawn_options' do
+        expect(options.spawn_options).to include(**options_hash)
+      end
+    end
+
+    context 'with an array of Integers and IOs' do
+      let(:options_hash) { { [1, $stderr] => File::NULL } }
+
+      it 'should allow the option' do
+        expect { options }.not_to raise_error
+      end
+
+      it 'should include the option in #spawn_options' do
+        expect(options.spawn_options).to include(**options_hash)
+      end
+    end
+
+    context 'with a Symbol source' do
+      let(:options_hash) { { out: File::NULL } }
+
+      it 'allow the option' do
+        expect { options }.not_to raise_error
+      end
+
+      it 'should include the option in #spawn_options' do
+        expect(options.spawn_options).to include(**options_hash)
+      end
+    end
   end
 
   describe '#spawn_options' do


### PR DESCRIPTION
Enhance `SpawnOptions` to accept `Integer` and `IO` as valid redirection sources. 

Update validation methods to accommodate these new types and add tests to ensure correct behavior with various input scenarios.

This does not (yet) allow these options to be used by ProcessExecuter.run as requested by #91. That will be addressed in an upcoming PR.