### PR TITLE
Remove merge option from ProcessExecuter.run

### DIFF
--- a/lib/process_executer.rb
+++ b/lib/process_executer.rb
@@ -99,14 +99,11 @@ module ProcessExecuter
   #      which can be accessed via the Result object in `result.options.out`. The
   #      same applies to `err`.
   #
-  #   2. If `merge` is set to `true`, stdout and stderr are captured to the same
-  #      buffer.
-  #
-  #   3. `out` and `err` are automatically wrapped in a
+  #   2. `out` and `err` are automatically wrapped in a
   #      `ProcessExecuter::MonitoredPipe` object so that any object that implements
   #      `#write` (or an Array of such objects) can be given for `out` and `err`.
   #
-  #   4. Raises one of the following errors unless `raise_errors` is explicitly set
+  #   3. Raises one of the following errors unless `raise_errors` is explicitly set
   #      to `false`:
   #
   #      * `ProcessExecuter::FailedError` if the command returns a non-zero
@@ -117,10 +114,10 @@ module ProcessExecuter
   #
   #      If `raise_errors` is false, the returned Result object will contain the error.
   #
-  #   5. Raises a `ProcessExecuter::ProcessIOError` if an exception is raised
+  #   4. Raises a `ProcessExecuter::ProcessIOError` if an exception is raised
   #      while collecting subprocess output. This can not be turned off.
   #
-  #   6. If a `logger` is provided, it will be used to log:
+  #   5. If a `logger` is provided, it will be used to log:
   #
   #      * The command that was executed and its status to `info` level
   #      * The stdout and stderr output to `debug` level
@@ -215,7 +212,7 @@ module ProcessExecuter
   #
   # @example Capture stdout and stderr into a single buffer
   #   command = ['echo "stdout" && echo "stderr" 1>&2']
-  #   result = ProcessExecuter.run(*command, merge: true)
+  #   result = ProcessExecuter.run(*command, [out:, err:]: StringIO.new)
   #   result.stdout #=> "stdout\nstderr\n"
   #   result.stderr #=> "stdout\nstderr\n"
   #   result.stdout.object_id == result.stderr.object_id #=> true
@@ -278,7 +275,6 @@ module ProcessExecuter
   #
   # @option options_hash [#write] :out (nil) The object to write stdout to
   # @option options_hash [#write] :err (nil) The object to write stderr to
-  # @option options_hash [Boolean] :merge (false) If true, stdout and stderr are written to the same capture buffer
   # @option options_hash [Boolean] :raise_errors (true) Raise an exception if the command fails
   # @option options_hash [Boolean] :unsetenv_others (false) If true, unset all environment variables before
   #   applying the new ones

--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -5,3 +5,8 @@ require_relative 'options/spawn_options'
 require_relative 'options/spawn_and_wait_options'
 require_relative 'options/run_options'
 require_relative 'options/option_definition'
+
+module ProcessExecuter
+  # Options related to spawning or running a command
+  module Options; end
+end

--- a/lib/process_executer/options/run_options.rb
+++ b/lib/process_executer/options/run_options.rb
@@ -20,7 +20,6 @@ module ProcessExecuter
       def define_options
         [
           *super,
-          OptionDefinition.new(:merge, default: false, validator: method(:validate_merge)),
           OptionDefinition.new(:raise_errors, default: true, validator: method(:validate_raise_errors)),
           OptionDefinition.new(:logger, default: Logger.new(nil), validator: method(:validate_logger))
         ].freeze
@@ -37,20 +36,6 @@ module ProcessExecuter
         raise(
           ArgumentError,
           "raise_errors must be true or false but was #{raise_errors.inspect}"
-        )
-        # :nocov:
-      end
-
-      # Validate the merge option value
-      # @return [String, nil] the error message if the value is not valid
-      # @api private
-      def validate_merge
-        return if [true, false].include?(merge)
-
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
-        raise(
-          ArgumentError,
-          "merge must be true or false but was #{merge.inspect}"
         )
         # :nocov:
       end

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -33,12 +33,8 @@ module ProcessExecuter
     #
     def call(command, options)
       options.out = StringIO.new if options.out == :not_set
+      options.err = StringIO.new if options.err == :not_set
 
-      if options.merge
-        options.err = options.out
-      elsif options.err == :not_set
-        options.err = StringIO.new
-      end
       spawn(command, options).tap { |result| process_result(result) }
     end
 
@@ -58,7 +54,7 @@ module ProcessExecuter
     #
     def spawn(command, options)
       options.out = ProcessExecuter::MonitoredPipe.new(options.out)
-      options.err = (options.merge ? options.out : ProcessExecuter::MonitoredPipe.new(options.err))
+      options.err = ProcessExecuter::MonitoredPipe.new(options.err)
 
       ProcessExecuter.spawn_and_wait_with_options(command, options)
     ensure

--- a/spec/process_executer/options/run_options_spec.rb
+++ b/spec/process_executer/options/run_options_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
           chdir: :not_set,
           timeout_after: nil,
           logger: be_a(Logger).and(satisfy { |logger| logger.instance_variable_get(:@logdev).nil? }),
-          merge: false,
           raise_errors: true
         )
         expect(subject.logger.instance_variable_get(:@logdev)).to be_nil
@@ -68,27 +67,6 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
           raise_error(
             ArgumentError,
             'logger must respond to #info and #debug but was "invalid"'
-          )
-        )
-      end
-    end
-
-    context 'when giving true for merge' do
-      let(:options_hash) { { merge: true } }
-
-      it 'should set merge to true' do
-        expect(subject.merge).to eq(true)
-      end
-    end
-
-    context 'when given an invalid merge value' do
-      let(:options_hash) { { merge: 'invalid' } }
-
-      it 'should raise an error' do
-        expect { subject }.to(
-          raise_error(
-            ArgumentError,
-            'merge must be true or false but was "invalid"'
           )
         )
       end
@@ -140,13 +118,12 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
   describe '#spawn_options' do
     subject { options.spawn_options }
 
-    context 'when timeout_after, merge, and raise_errors are set' do
-      let(:options_hash) { { timeout_after: 10, merge: true, raise_errors: false } }
+    context 'when timeout_after and raise_errors are set' do
+      let(:options_hash) { { timeout_after: 10, raise_errors: false } }
 
-      it 'should not include the timeout_after, merge, or raise_errors options' do
+      it 'should not include the timeout_after or raise_errors options' do
         aggregate_failures do
           expect(subject).not_to have_key(:timeout_after)
-          expect(subject).not_to have_key(:merge)
           expect(subject).not_to have_key(:raise_errors)
         end
       end

--- a/spec/process_executer/options_conversions_spec.rb
+++ b/spec/process_executer/options_conversions_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ProcessExecuter do
     subject { ProcessExecuter.run_options(given_options) }
 
     context 'when given options is a Hash' do
-      let(:given_options) { { merge: true } }
+      let(:given_options) { { logger: Logger.new(nil) } }
       it 'should return a RunOptions object with the same options' do
         expect(subject).to be_a(ProcessExecuter::Options::RunOptions)
         expect(subject.to_h).to include(given_options)
@@ -65,7 +65,7 @@ RSpec.describe ProcessExecuter do
     end
 
     context 'when given options is a ProcessExecuter::Options::RunOptions' do
-      let(:given_options) { ProcessExecuter::Options::RunOptions.new(merge: true) }
+      let(:given_options) { ProcessExecuter::Options::RunOptions.new(logger: Logger.new(nil)) }
       it 'should return the given object' do
         expect(subject.object_id).to eq(given_options.object_id)
       end

--- a/spec/process_executer_run_spec.rb
+++ b/spec/process_executer_run_spec.rb
@@ -252,23 +252,6 @@ RSpec.describe ProcessExecuter do
       end
     end
 
-    context 'merge stdout and stderr' do
-      let(:command) { ruby_command <<~COMMAND }
-        puts 'stdout output'
-        STDERR.puts 'stderr output'
-      COMMAND
-
-      let(:options) { { merge: true } }
-
-      it 'is expected to merge stdout and stderr' do
-        # The order these strings are concatenated is not guaranteed
-        expect(subject.stdout.gsub("\r\n", "\n")).to include("stdout output\n")
-        expect(subject.stdout.gsub("\r\n", "\n")).to include("stderr output\n")
-        expect(subject.stderr.gsub("\r\n", "\n")).to include("stdout output\n")
-        expect(subject.stderr.gsub("\r\n", "\n")).to include("stderr output\n")
-      end
-    end
-
     context 'buffers are given for stdout and stderr' do
       let(:out) { StringIO.new }
       let(:err) { StringIO.new }


### PR DESCRIPTION
Eliminate the `:merge` option from `ProcessExecuter.run` to allow users to handle output redirection more flexibly. 

Users should use the following syntax to merge stdout and stderr redirection:

```
# Three different ways to specify the source:
[:out, :err] => destination
[1, 2] => destination
[STDOUT, STDERR] => destination
```