### PR TITLE
Allow Integer or IO as redirection sources

### DIFF
--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -94,6 +94,32 @@ module ProcessExecuter
         @options.dup
       end
 
+      # Iterate over each option
+      # @example
+      #   options = ProcessExecuter::Options.new(option1: 'value1', option2: 'value2')
+      #   options.each { |option_key, option_value| puts "#{option_key}: #{option_value}" }
+      #   # option1: value1
+      #   # option2: value2
+      #
+      # @yield [option_key, option_value]
+      # @return [void]
+      def each(&)
+        @options.each(&)
+      end
+
+      # Merge the given options into the current options
+      # @example
+      #   options = ProcessExecuter::Options.new(option1: 'value1', option2: 'value2')
+      #   options.merge!(option2: 'new_value2', option3: 'value3')
+      #   options.option2 # => 'new_value2'
+      #   options.option3 # => 'value3'
+      #
+      # @param other_options [Hash] the options to merge into the current options
+      # @return [void]
+      def merge!(**other_options)
+        @options.merge!(other_options)
+      end
+
       protected
 
       # An array of OptionDefinition objects that define the allowed options

--- a/lib/process_executer/options/spawn_options.rb
+++ b/lib/process_executer/options/spawn_options.rb
@@ -9,18 +9,13 @@ module ProcessExecuter
     #
     # Allow subclasses to add additional options that are not passed to `Process.spawn`
     #
-    # Valid options are those accepted by Process.spawn plus the following additions:
-    #
-    # * `:timeout_after`: the number of seconds to allow a process to run before killing it
+    # Valid options are those accepted by Process.spawn.
     #
     # @api public
     #
     class SpawnOptions < Base
       # :nocov: SimpleCov on JRuby reports hashes declared on multiple lines as not covered
       SPAWN_OPTIONS = [
-        OptionDefinition.new(:in, default: :not_set),
-        OptionDefinition.new(:out, default: :not_set),
-        OptionDefinition.new(:err, default: :not_set),
         OptionDefinition.new(:unsetenv_others, default: :not_set),
         OptionDefinition.new(:pgroup, default: :not_set),
         OptionDefinition.new(:new_pgroup, default: :not_set),
@@ -45,6 +40,66 @@ module ProcessExecuter
             spawn_options[option_key] = value if include_spawn_option?(option_key, value)
           end
         end
+      end
+
+      # Determine if the given option key indicates a redirection option
+      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
+      # @return [Boolean]
+      # @api private
+      def redirection?(option_key)
+        test = ->(key) { %i[in out err].include?(key) || key.is_a?(Integer) || (key.is_a?(IO) && !key.fileno.nil?) }
+        test.call(option_key) || (option_key.is_a?(Array) && option_key.all? { |key| test.call(key) })
+      end
+
+      # Does option_key indicate a standard redirection such as stdin, stdout, or stderr
+      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
+      # @param symbol [:in, :out, :err] the symbol to test for
+      # @param fileno [Integer] the file descriptor number to test for
+      # @return [Boolean]
+      # @api private
+      def std_redirection?(option_key, symbol, fileno)
+        test = ->(key) { key == symbol || key == fileno || (key.is_a?(IO) && key.fileno == fileno) }
+        test.call(option_key) || (option_key.is_a?(Array) && option_key.any? { |key| test.call(key) })
+      end
+
+      # Determine if the given option key indicates a redirection option for stdout
+      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
+      # @return [Boolean]
+      # @api private
+      def stdout_redirection?(option_key) = std_redirection?(option_key, :out, 1)
+
+      # Determine the option key that indicates a redirection option for stdout
+      # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # @api private
+      def stdout_redirection_key
+        options.keys.find { |option_key| option_key if stdout_redirection?(option_key) }
+      end
+
+      # Determine the value of the redirection option for stdout
+      # @return [Object]
+      # @api private
+      def stdout_redirection_value
+        options[stdout_redirection_key]
+      end
+
+      # Determine if the given option key indicates a redirection option for stderr
+      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
+      # @return [Boolean]
+      # @api private
+      def stderr_redirection?(option_key) = std_redirection?(option_key, :err, 2)
+
+      # Determine the option key that indicates a redirection option for stderr
+      # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # @api private
+      def stderr_redirection_key
+        options.keys.find { |option_key| option_key if stderr_redirection?(option_key) }
+      end
+
+      # Determine the value of the redirection option for stderr
+      # @return [Object]
+      # @api private
+      def stderr_redirection_value
+        options[stderr_redirection_key]
       end
 
       private
@@ -73,41 +128,15 @@ module ProcessExecuter
       def include_spawn_option?(option_key, value)
         return false if value == :not_set
 
-        redirection_option?(option_key) || SPAWN_OPTIONS.any? { |o| o.name == option_key }
-      end
-
-      # Determine if the given option key indicates a non-array redirection option
-      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
-      # @return [Boolean]
-      # @api private
-      def non_array_redirection_option?(option_key)
-        %i[in out err].include?(option_key) ||
-          option_key.is_a?(Integer) ||
-          (option_key.is_a?(IO) && !option_key.fileno.nil?)
-      end
-
-      # Determine if the given option key indicates an array redirection option
-      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
-      # @return [Boolean]
-      # @api private
-      def array_redirection_option?(option_key)
-        option_key.is_a?(Array) && option_key.all? { |source| non_array_redirection_option?(source) }
-      end
-
-      # Determine if the given option key indicates a redirection option
-      # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
-      # @return [Boolean]
-      # @api private
-      def redirection_option?(option_key)
-        non_array_redirection_option?(option_key) || array_redirection_option?(option_key)
+        redirection?(option_key) || SPAWN_OPTIONS.any? { |o| o.name == option_key }
       end
 
       # Spawn allows IO object and integers as options
-      # @param option [Symbol] the option to be tested
+      # @param option_key [Symbol] the option to be tested
       # @return [Boolean] true if the given option is a valid option
       # @api private
       def valid_option?(option_key)
-        super || redirection_option?(option_key)
+        super || redirection?(option_key)
       end
     end
   end

--- a/lib/process_executer/result.rb
+++ b/lib/process_executer/result.rb
@@ -121,7 +121,7 @@ module ProcessExecuter
     # @return [String, nil]
     #
     def stdout
-      pipe = options.out
+      pipe = options.stdout_redirection_value
       return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
 
       pipe.destination.string
@@ -141,7 +141,7 @@ module ProcessExecuter
     # @return [String, nil]
     #
     def stderr
-      pipe = options.err
+      pipe = options.stderr_redirection_value
       return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
 
       pipe.destination.string

--- a/spec/process_executer/options/run_options_spec.rb
+++ b/spec/process_executer/options/run_options_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
     context 'when no options are given' do
       it 'should set all options to their default values' do
         expect(subject).to have_attributes(
-          in: :not_set,
-          out: :not_set,
-          err: :not_set,
           unsetenv_others: :not_set,
           pgroup: :not_set,
           new_pgroup: :not_set,

--- a/spec/process_executer/options/spawn_and_wait_options_spec.rb
+++ b/spec/process_executer/options/spawn_and_wait_options_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe ProcessExecuter::Options::SpawnAndWaitOptions do
     context 'when no options are given' do
       it 'should set all options to their default values' do
         expect(subject).to have_attributes(
-          in: :not_set,
-          out: :not_set,
-          err: :not_set,
           unsetenv_others: :not_set,
           pgroup: :not_set,
           new_pgroup: :not_set,

--- a/spec/process_executer/options/spawn_options_spec.rb
+++ b/spec/process_executer/options/spawn_options_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe ProcessExecuter::Options::SpawnOptions do
     context 'when no options are given' do
       it 'should set all options to their default values' do
         expect(subject).to have_attributes(
-          in: :not_set,
-          out: :not_set,
-          err: :not_set,
           unsetenv_others: :not_set,
           pgroup: :not_set,
           new_pgroup: :not_set,

--- a/spec/process_executer_run_spec.rb
+++ b/spec/process_executer_run_spec.rb
@@ -420,5 +420,122 @@ RSpec.describe ProcessExecuter do
         end
       end
     end
+
+    describe 'capturing stdout and stderr' do
+      context "when given { out: 'stdout.txt' }" do
+        let(:command) { ruby_command "STDOUT.puts 'stdout output'" }
+        let(:options) { { out: 'stdout.txt' } }
+        it 'should capture stdout to the stdout.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stdout.txt').gsub("\r\n", "\n")).to eq("stdout output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { 1: 'stdout.txt' }" do
+        let(:command) { ruby_command "STDOUT.puts 'stdout output'" }
+        let(:options) { { 1 => 'stdout.txt' } }
+        it 'should capture stdout to the stdout.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stdout.txt').gsub("\r\n", "\n")).to eq("stdout output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { STDOUT => 'stdout.txt' }" do
+        let(:command) { ruby_command "STDOUT.puts 'stdout output'" }
+        let(:options) { { $stdout => 'stdout.txt' } }
+        it 'should capture stdout to the stdout.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stdout.txt').gsub("\r\n", "\n")).to eq("stdout output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { err: 'stderr.txt' }" do
+        let(:command) { ruby_command "STDERR.puts 'stderr output'" }
+        let(:options) { { err: 'stderr.txt' } }
+        it 'should capture stderr to the stderr.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stderr.txt').gsub("\r\n", "\n")).to eq("stderr output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { 2 => 'stderr.txt' }" do
+        let(:command) { ruby_command "STDERR.puts 'stderr output'" }
+        let(:options) { { 2 => 'stderr.txt' } }
+        it 'should capture stderr to the stderr.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stderr.txt').gsub("\r\n", "\n")).to eq("stderr output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { STDERR => 'stderr.txt' }" do
+        let(:command) { ruby_command "STDERR.puts 'stderr output'" }
+        let(:options) { { $stderr => 'stderr.txt' } }
+        it 'should capture stderr to the stderr.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stderr.txt').gsub("\r\n", "\n")).to eq("stderr output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { out: 'stdout.txt', err: 'stderr.txt' }" do
+        let(:command) { ruby_command "STDOUT.puts 'stdout output'; STDERR.puts 'stderr output'" }
+        let(:options) { { out: 'stdout.txt', err: 'stderr.txt' } }
+
+        it 'should capture stdout to the stdout.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stdout.txt').gsub("\r\n", "\n")).to eq("stdout output\n")
+            end
+          end
+        end
+
+        it 'should capture stderr to the stderr.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('stderr.txt').gsub("\r\n", "\n")).to eq("stderr output\n")
+            end
+          end
+        end
+      end
+
+      context "when given { [1, 2] => 'output.txt' }" do
+        let(:command) { ruby_command "STDOUT.puts 'stdout output'; STDERR.puts 'stderr output'" }
+        let(:options) { { [1, 2] => 'output.txt' } }
+        it 'should capture both stdout and stderr to output.txt' do
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              ProcessExecuter.run(*command, **options)
+              expect(File.read('output.txt').gsub("\r\n", "\n")).to match(/^stdout output\n/)
+              expect(File.read('output.txt').gsub("\r\n", "\n")).to match(/^stderr output\n/)
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Enable the use of Integer or IO objects as valid redirection sources for process execution.

Fixes #91