### PR TITLE
Support redirection destinations for child and close actions

### DIFF
--- a/lib/process_executer/destination_base.rb
+++ b/lib/process_executer/destination_base.rb
@@ -62,5 +62,22 @@ module ProcessExecuter
     def self.handles?(destination)
       raise NotImplementedError
     end
+
+    # Determines if this destination class can be wrapped by MonitoredPipe
+    #
+    # All destination types can be wrapped by MonitoredPipe unless they explicitly
+    # opt out.
+    #
+    # @return [Boolean]
+    # @api private
+    def self.compatible_with_monitored_pipe? = true
+
+    # Determines if this destination instance can be wrapped by MonitoredPipe
+    #
+    # @return [Boolean]
+    # @api private
+    def compatible_with_monitored_pipe?
+      self.class.compatible_with_monitored_pipe?
+    end
   end
 end

--- a/lib/process_executer/destinations/child_redirection.rb
+++ b/lib/process_executer/destinations/child_redirection.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ProcessExecuter
+  module Destinations
+    # Handles generic objects that respond to write
+    #
+    # @api private
+    class ChildRedirection < ProcessExecuter::DestinationBase
+      # Determines if this class can handle the given destination
+      #
+      # @param destination [Object] the destination to check
+      # @return [Boolean] true if destination responds to write but is not an IO with fileno
+      def self.handles?(destination)
+        destination.is_a?(Array) && destination.size == 2 && destination[0] == :child
+      end
+
+      # This class should not be wrapped in a monitored pipe
+      # @return [Boolean]
+      # @api private
+      def self.compatible_with_monitored_pipe? = false
+    end
+  end
+end

--- a/lib/process_executer/destinations/close.rb
+++ b/lib/process_executer/destinations/close.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ProcessExecuter
+  module Destinations
+    # Handles generic objects that respond to write
+    #
+    # @api private
+    class Close < ProcessExecuter::DestinationBase
+      # Determines if this class can handle the given destination
+      #
+      # @param destination [Object] the destination to check
+      # @return [Boolean] true if destination responds to write but is not an IO with fileno
+      def self.handles?(destination)
+        destination == :close
+      end
+
+      # This class should not be wrapped in a monitored pipe
+      # @return [Boolean]
+      # @api private
+      def self.compatible_with_monitored_pipe? = false
+    end
+  end
+end

--- a/lib/process_executer/monitored_pipe.rb
+++ b/lib/process_executer/monitored_pipe.rb
@@ -55,6 +55,9 @@ module ProcessExecuter
     #
     def initialize(redirection_destination, chunk_size: 100_000)
       @destination = Destinations.factory(redirection_destination)
+
+      assert_destination_is_compatible_with_monitored_pipe
+
       @chunk_size = chunk_size
       @pipe_reader, @pipe_writer = IO.pipe
       @state = :open
@@ -251,6 +254,16 @@ module ProcessExecuter
     attr_reader :exception
 
     private
+
+    # Raise an error if the destination is not compatible with MonitoredPipe
+    # @return [void]
+    # @raise [ArgumentError] if the destination is not compatible with MonitoredPipe
+    # @api private
+    def assert_destination_is_compatible_with_monitored_pipe
+      return if destination.compatible_with_monitored_pipe?
+
+      raise ArgumentError, "Destination #{destination.destination} is not compatible with MonitoredPipe"
+    end
 
     # Read data from the pipe until `#state` is changed to `:closing`
     #

--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -94,17 +94,15 @@ module ProcessExecuter
         @options.dup
       end
 
-      # Iterate over each option
+      # Iterate over each option with an object
       # @example
       #   options = ProcessExecuter::Options.new(option1: 'value1', option2: 'value2')
-      #   options.each { |option_key, option_value| puts "#{option_key}: #{option_value}" }
-      #   # option1: value1
-      #   # option2: value2
-      #
-      # @yield [option_key, option_value]
+      #   options.each_with_object({}) { |(option_key, option_value), obj| obj[option_key] = option_value }
+      #   # => { option1: "value1", option2: "value2" }
+      # @yield [option_key, option_value, obj]
       # @return [void]
-      def each(&)
-        @options.each(&)
+      def each_with_object(obj, &)
+        @options.each_with_object(obj, &)
       end
 
       # Merge the given options into the current options

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # redirect the source to the destination fd in the child process
       it 'should raise an error' do
         expect { ProcessExecuter::MonitoredPipe.new([:child, 1]) }.to(
-          raise_error(ArgumentError, 'wrong exec redirect action')
+          raise_error(ArgumentError, 'Destination [:child, 1] is not compatible with MonitoredPipe')
         )
       end
     end


### PR DESCRIPTION
Introduce support for redirection destinations in the form of `[:child, fd]` and `:close`. 

Ensure compatibility checks for these new destination types within the MonitoredPipe class. Raise an error if you try to wrap a destination with a MonitoredPipe when that destination is not an output.

Update tests to validate the behavior of these redirection options.