### PR TITLE
Report all option validation errors

### DIFF
--- a/lib/process_executer/options/run_options.rb
+++ b/lib/process_executer/options/run_options.rb
@@ -32,12 +32,7 @@ module ProcessExecuter
       def validate_raise_errors
         return if [true, false].include?(raise_errors)
 
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
-        raise(
-          ArgumentError,
-          "raise_errors must be true or false but was #{raise_errors.inspect}"
-        )
-        # :nocov:
+        errors << "raise_errors must be true or false but was #{raise_errors.inspect}"
       end
 
       # Validate the logger option value
@@ -46,12 +41,7 @@ module ProcessExecuter
       def validate_logger
         return if logger.respond_to?(:info) && logger.respond_to?(:debug)
 
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
-        raise(
-          ArgumentError,
-          "logger must respond to #info and #debug but was #{logger.inspect}"
-        )
-        # :nocov:
+        errors << "logger must respond to #info and #debug but was #{logger.inspect}"
       end
     end
   end

--- a/lib/process_executer/options/spawn_and_wait_options.rb
+++ b/lib/process_executer/options/spawn_and_wait_options.rb
@@ -32,12 +32,7 @@ module ProcessExecuter
         return if timeout_after.nil?
         return if timeout_after.is_a?(Numeric) && timeout_after.real? && !timeout_after.negative?
 
-        # :nocov: SimpleCov on SimpleCov on JRuby reports the last with the last argument line is not covered
-        raise(
-          ArgumentError,
-          "timeout_after must be nil or a non-negative real number but was #{timeout_after.inspect}"
-        )
-        # :nocov:
+        errors << "timeout_after must be nil or a non-negative real number but was #{timeout_after.inspect}"
       end
     end
   end

--- a/spec/process_executer/options/base_spec.rb
+++ b/spec/process_executer/options/base_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe ProcessExecuter::Options::Base do
         end
 
         def validate_option1
-          raise ArgumentError, 'option1 must be a String' unless option1.is_a?(String)
+          errors << 'option1 must be a String' unless option1.is_a?(String)
         end
       end
 
@@ -235,7 +235,7 @@ RSpec.describe ProcessExecuter::Options::Base do
         end
 
         def validate_option2
-          raise ArgumentError, 'option2 must be an Integer' unless option2.is_a?(Integer)
+          errors << 'option2 must be an Integer' unless option2.is_a?(Integer)
         end
       end
     end
@@ -320,6 +320,14 @@ RSpec.describe ProcessExecuter::Options::Base do
 
           it 'should raise an ArgumentError' do
             expect { subject }.to raise_error(ArgumentError, 'option2 must be an Integer')
+          end
+        end
+
+        context 'when given an invalid value for both option1 and option2' do
+          let(:options_hash) { { option1: 123, option2: 'invalid' } }
+
+          it 'should raise an ArgumentError' do
+            expect { subject }.to raise_error(ArgumentError, "option1 must be a String\noption2 must be an Integer")
           end
         end
       end


### PR DESCRIPTION
Collect all validation errors for options and raise a single ArgumentError with a comprehensive message instead of stopping at the first error. This change enhances error reporting during option validation.

Fixes #97