### PR TITLE
Wrap errors raised by Process.spawn in a ProcessExecuter::SpawnError

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ following features:
 * It raises an error if there is any problem with the subprocess. This behavior can
   be turned off with the `raise_errors: false` option.
 
+  ⚠️ `ProcessIOError` and `SpawnError` errors are not suppressed by giving the
+  `raise_errors: false` option.
+
 ```ruby
 result = ProcessExecuter.run('echo "Hello World"', out: StringIO.new)
 result.stdout #=> "Hello World\n"

--- a/lib/process_executer.rb
+++ b/lib/process_executer.rb
@@ -87,7 +87,11 @@ module ProcessExecuter
   # @return [ProcessExecuter::Result] The result of the completed subprocess
   # @api private
   def self.spawn_and_wait_with_options(command, options)
-    pid = Process.spawn(*command, **options.spawn_options)
+    begin
+      pid = Process.spawn(*command, **options.spawn_options)
+    rescue StandardError => e
+      raise ProcessExecuter::SpawnError, "Failed to spawn process: #{e.message}"
+    end
     wait_for_process(pid, command, options)
   end
 
@@ -287,10 +291,7 @@ module ProcessExecuter
   # @option options_hash [String] :chdir (nil) The directory to run the command in
   # @option options_hash [Logger] :logger The logger to use
   #
-  # @raise [ProcessExecuter::FailedError] if the command returned a non-zero exit status
-  # @raise [ProcessExecuter::SignaledError] if the command exited because of an unhandled signal
-  # @raise [ProcessExecuter::TimeoutError] if the command timed out
-  # @raise [ProcessExecuter::ProcessIOError] if an exception was raised while collecting subprocess output
+  # @raise [ProcessExecuter::Error] if the command could not be executed or failed
   #
   # @return [ProcessExecuter::Result] The result of the completed subprocess
   #

--- a/lib/process_executer/errors.rb
+++ b/lib/process_executer/errors.rb
@@ -17,7 +17,8 @@ module ProcessExecuter
   #       │   ├─> FailedError
   #       │   └─> SignaledError
   #       │       └─> TimeoutError
-  #       └─> ProcessIOError
+  #       ├─> ProcessIOError
+  #       └─> SpawnError
   # ```
   #
   # | Error Class | Description |
@@ -28,6 +29,7 @@ module ProcessExecuter
   # | `SignaledError` | Raised when the command is terminated as a result of receiving a signal. This could happen if the process is forcibly terminated or if there is a serious system error. |
   # | `TimeoutError` | This is a specific type of `SignaledError` that is raised when the command times out and is killed via the SIGKILL signal. Raised when the operation takes longer than the specified timeout duration (if provided). |
   # | `ProcessIOError` | Raised when an error was encountered reading or writing to the command's subprocess. |
+  # | `SpawnError` | Raised when the process could not execute. Check the  |
   #
   # @example Rescuing any error
   #   begin
@@ -129,6 +131,14 @@ module ProcessExecuter
   # @api public
   #
   class ProcessIOError < ProcessExecuter::Error; end
+
+  # Raised when spawn could not execute the process
+  #
+  # See the `cause` for the exception that Process.spawn raised.
+  #
+  # @api public
+  #
+  class SpawnError < ProcessExecuter::Error; end
 end
 
 # rubocop:enable Layout/LineLength

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -42,8 +42,7 @@ module ProcessExecuter
     # @param command [Array<String>] The command to execute
     # @param options [ProcessExecuter::Options::RunOptions] Options for running the command
     #
-    # @raise [ProcessExecuter::ProcessIOError] If an exception was raised while collecting subprocess output
-    # @raise [ProcessExecuter::TimeoutError] If the command times out
+    # @raise [ProcessExecuter::Error] if the command could not be executed or failed
     #
     # @return [ProcessExecuter::Result] The result of the completed subprocess
     #
@@ -100,10 +99,7 @@ module ProcessExecuter
     #
     # @return [Void]
     #
-    # @raise [ProcessExecuter::FailedError] If the command failed
-    # @raise [ProcessExecuter::SignaledError] If the command was signaled
-    # @raise [ProcessExecuter::TimeoutError] If the command times out
-    # @raise [ProcessExecuter::ProcessIOError] If an exception was raised while collecting subprocess output
+    # @raise [ProcessExecuter::Error] if the command could not be executed or failed
     #
     # @api private
     #

--- a/spec/process_executer_spawn_and_wait_spec.rb
+++ b/spec/process_executer_spawn_and_wait_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe ProcessExecuter do
   describe '.spawn_and_wait' do
     subject { ProcessExecuter.spawn_and_wait(*command, **options) }
 
+    context 'when an invalid command is given' do
+      let(:command) { 'invalid_command' }
+      let(:options) { {} }
+      it 'should raise an ProcessExecuter::SpawnError with the cause set' do
+        expect { subject }.to(
+          raise_error(ProcessExecuter::SpawnError) { |e| expect(e.cause).to be_a Errno::ENOENT }
+        )
+      end
+    end
+
     context 'when :timeout_after is specified' do
       context 'when :timeout_after is a String' do
         let(:command) { %w[echo hello] }


### PR DESCRIPTION
The errors raised by `Process.spawn` for each error condition are inconsistent between different Ruby engines. This change wraps any exception raised by `Process.spawn` in a `ProcessExecuter::SpawnError` so that client code can more easily deal with these problems.

The actual error raised by `Process.spawn` is accessible from the `#cause` method.

`SpawnError`s are not suppressed by the `raise_errors: false` option.