### PR TITLE
Add test for SpawnError handling in ProcessExecuter

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,4 +12,6 @@ require 'process_executer'
 # Pry.start
 
 require 'irb'
+require_relative '../spec/spec_helper'
+
 IRB.start(__FILE__)

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
             # Give Windows time to release the file lock
             # so that Dir.mktmpdir can delete the directory
             #
-            sleep 0.1 if windows?
+            sleep 0.5 if windows?
 
             # We should try to model what happens in this command:
             #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rspec'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -12,10 +14,22 @@ RSpec.configure do |config|
   end
 end
 
-def windows? = Gem.win_platform?
+# Check if the Ruby interpreter is JRuby or TruffleRuby
 def truffleruby? = RUBY_ENGINE == 'truffleruby'
 def jruby? = RUBY_ENGINE == 'jruby'
 def mri? = RUBY_ENGINE == 'ruby'
+
+if jruby?
+  require 'java'
+  def os_name = (@os_name = java.lang.System.getProperty('os.name').downcase)
+  def windows? = os_name.include?('win')
+  def mac? = os_name.include?('mac') || os_name.include?('darwin')
+  def linux? = os_name.include?('nix') || os_name.include?('nux') || os_name.include?('aix')
+else
+  def windows? = Gem.win_platform?
+  def mac? = RUBY_PLATFORM.match?(/darwin/)
+  def linux? = RUBY_PLATFORM.match?(/linux/)
+end
 
 def ruby_command(code)
   @ruby_path ||=


### PR DESCRIPTION
Introduce tests to ensure that a SpawnError is raised when Process.spawn encounters an error, covering various scenarios including invalid commands and non-existent directories. 

Adjustments were also made to the test environment and configurations are also included.