### PR TITLE
Fix flaky test on Windows

### DIFF
--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -177,14 +177,11 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
             filepath = File.join(dir, 'output.txt')
             File.write(filepath, 'initial content')
             monitored_pipe = ProcessExecuter::MonitoredPipe.new([filepath, 'r'])
-            _pid, _status = Process.wait2(Process.spawn(*command, out: monitored_pipe))
-            monitored_pipe.close
-            FileUtils.rm(filepath)
-
-            # Give Windows time to release the file lock
-            # so that Dir.mktmpdir can delete the directory
-            #
-            sleep 0.5 if windows?
+            begin
+              _pid, _status = Process.wait2(Process.spawn(*command, out: monitored_pipe))
+            ensure
+              monitored_pipe.close
+            end
 
             # We should try to model what happens in this command:
             #


### PR DESCRIPTION
Address a flaky test issue that occurs specifically on Windows by ensuring proper resource cleanup after process execution.