### PR TITLE
Integrate track_open_instances gem for monitoring leaks

### DIFF
--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
     'Ruby: MRI 3.1 or later, TruffleRuby 24 or later, or JRuby 9.4 or later'
   ]
 
+  spec.add_dependency 'track_open_instances', '~> 0.1'
+
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'create_github_release', '~> 2.1'
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -169,6 +169,14 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
 
     context 'when the output destination is an array in the form [filepath, mode]' do
       context 'when mode is "r"' do
+        # before do
+        #   ProcessExecuter::MonitoredPipe.assert_no_open_instances
+        # end
+
+        # after do
+        #   ProcessExecuter::MonitoredPipe.assert_no_open_instances
+        # end
+
         it 'should raise an ArgumentError' do
           command = ruby_command(<<~COMMAND)
             puts 'stdout output'


### PR DESCRIPTION
Integrate the track_open_instances gem to monitor and report on leaked MonitoredPipe instances, enhancing resource management and debugging capabilities.