### PR TITLE
Fix MonitoredPipe cleanup on IOError

### DIFF
--- a/lib/process_executer/monitored_pipe.rb
+++ b/lib/process_executer/monitored_pipe.rb
@@ -88,19 +88,14 @@ module ProcessExecuter
     #
     def close
       mutex.synchronize do
-        return unless state == :open
-
-        @state = :closing
-      end
-
-      mutex.synchronize do
-        condition_variable.wait(mutex) while @state != :closed
+        if state == :open
+          @state = :closing
+          condition_variable.wait(mutex) while @state != :closed
+        end
       end
 
       thread.join
-
       destination.close
-
       self.class.remove_open_instance(self)
     end
 
@@ -322,8 +317,6 @@ module ProcessExecuter
     # @api private
     def monitor
       monitor_pipe until state == :closing
-    # rescue StandardError => e
-    #   # Close everything as if `close` was called
     ensure
       close_pipe
       mutex.synchronize do

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -169,13 +169,13 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
 
     context 'when the output destination is an array in the form [filepath, mode]' do
       context 'when mode is "r"' do
-        # before do
-        #   ProcessExecuter::MonitoredPipe.assert_no_open_instances
-        # end
+        before do
+          ProcessExecuter::MonitoredPipe.assert_no_open_instances
+        end
 
-        # after do
-        #   ProcessExecuter::MonitoredPipe.assert_no_open_instances
-        # end
+        after do
+          ProcessExecuter::MonitoredPipe.assert_no_open_instances
+        end
 
         it 'should raise an ArgumentError' do
           command = ruby_command(<<~COMMAND)
@@ -610,6 +610,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         expect do
           monitored_pipe.write("hello world\n")
           sleep 0.01
+          monitored_pipe.close
         end.to output("hello world\n").to_stdout
       end
     end
@@ -621,6 +622,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         expect do
           monitored_pipe.write("hello world\n")
           sleep 0.01
+          monitored_pipe.close
         end.to output("hello world\n").to_stdout
       end
     end
@@ -632,6 +634,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         expect do
           monitored_pipe.write("hello world\n")
           sleep 0.01
+          monitored_pipe.close
         end.to output("hello world\n").to_stderr
       end
     end
@@ -643,6 +646,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
         expect do
           monitored_pipe.write("hello world\n")
           sleep 0.01
+          monitored_pipe.close
         end.to output("hello world\n").to_stderr
       end
     end
@@ -704,18 +708,21 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       it 'should eventually kill the monitoring thread' do
         monitored_pipe.write('hello')
         sleep(0.01)
+        monitored_pipe.close
         expect(monitored_pipe.thread.alive?).to eq(false)
       end
 
       it 'should eventually set the state to :closed' do
         monitored_pipe.write('hello')
         sleep(0.01)
+        monitored_pipe.close
         expect(monitored_pipe.state).to eq(:closed)
       end
 
       it 'should eventually save the exception raised to #exception' do
         monitored_pipe.write('hello')
         sleep(0.01)
+        monitored_pipe.close
         expect(monitored_pipe.exception).to be_a(Encoding::UndefinedConversionError)
         expect(monitored_pipe.exception.message).to eq('UTF-8 conversion error')
       end
@@ -723,6 +730,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       it 'should raise an exception if #write is called after the pipe is closed' do
         monitored_pipe.write('hello')
         sleep(0.01)
+        monitored_pipe.close
         expect { monitored_pipe.write('world') }.to raise_error(IOError, 'closed stream')
       end
     end

--- a/spec/process_executer_run_spec.rb
+++ b/spec/process_executer_run_spec.rb
@@ -356,13 +356,15 @@ RSpec.describe ProcessExecuter do
     end
 
     context 'when a pipe exception occurs' do
+      let(:stdout_buffer) { double('stdout') }
+      let(:stderr_buffer) { double('stderr') }
+
       before do
-        allow_any_instance_of(ProcessExecuter::MonitoredPipe).to(
-          receive(:exception).and_return(StandardError.new('pipe error'))
-        )
+        allow(stdout_buffer).to receive(:write).and_raise(IOError)
+        allow(stderr_buffer).to receive(:write).and_raise(IOError)
       end
 
-      subject { ProcessExecuter.run('echo Hello', out: StringIO.new, err: StringIO.new) }
+      subject { ProcessExecuter.run('echo Hello', out: stdout_buffer, err: stderr_buffer) }
 
       it 'is expected to raise ProcessExecuter::ProcessIOError' do
         expect { subject }.to raise_error(ProcessExecuter::ProcessIOError)

--- a/spec/process_executer_spawn_and_wait_spec.rb
+++ b/spec/process_executer_spawn_and_wait_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ProcessExecuter do
         let(:options) { { out: output_pipe, timeout_after: nil } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
+          output_pipe.close
         end
       end
 
@@ -52,6 +53,7 @@ RSpec.describe ProcessExecuter do
         let(:options) { { out: output_pipe, timeout_after: Integer(1) } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
+          output_pipe.close
         end
       end
 
@@ -62,6 +64,7 @@ RSpec.describe ProcessExecuter do
         let(:options) { { out: output_pipe, timeout_after: Float(1.0) } }
         it 'should NOT raise an error' do
           expect { subject }.not_to raise_error
+          output_pipe.close
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,12 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.after(:each) do
+    # Make sure there are no open instance of ProcessExecuter::MonitoredPipe
+    # after each test
+    ProcessExecuter::MonitoredPipe.assert_no_open_instances
+  end
 end
 
 # Check if the Ruby interpreter is JRuby or TruffleRuby


### PR DESCRIPTION
Ensure MonitoredPipe properly closes all pipes and cleans up after itself even when encountering an IOError. 

Update tests so that each test cleans up after itself by closing any MonitoredPipes it creates.

Add an assertion after every test to make sure that no open MonitoredPipe instances remain after operations.