### PR TITLE
fix: do not trigger build workflows after merging to main or for release PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 
@@ -22,6 +19,10 @@ jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
@@ -31,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: [true]
         include:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,9 +1,6 @@
 name: Experimental Ruby Builds
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Since all merges to the main branch must be a fast-forward rebase, CI
builds should not be run when merged to main. They are run via the
pull request before merging.

The continuous_integration workflow should be triggered for pull requests
targeting main.

The experimental_ruby_builds workflow should only be triggered manually via
the GitHub UI