### PR TITLE
feat!: refactor public interface

### DIFF
--- a/lib/process_executer.rb
+++ b/lib/process_executer.rb
@@ -32,285 +32,198 @@ require 'process_executer/runner'
 #
 # @api public
 module ProcessExecuter
-  # Run a command in a subprocess, wait for it to finish, then return the result
+  # Define shortcuts for SpawnWithTimeoutOptions
+  SpawnWithTimeoutOptions = ProcessExecuter::Options::SpawnWithTimeoutOptions
+  # Define shortcuts for RunOptions
+  RunOptions = ProcessExecuter::Options::RunOptions
+
+  # Spawn a command, wait for it to finish, then return the result
   #
-  # This method is a thin wrapper around
-  # [Process.spawn](https://docs.ruby-lang.org/en/3.3/Process.html#method-c-spawn)
-  # and blocks until the command terminates.
+  # This command is a wrapper around Process.spawn and Process.waitpid2.
   #
-  # A timeout may be specified with the `:timeout_after` option. The command will be
-  # sent the SIGKILL signal if it does not terminate within the specified timeout.
+  # A {ProcessExecuter::ArgumentError} will be raised if both options and
+  # options_hash are given.
   #
-  # @example
-  #   result = ProcessExecuter.spawn_and_wait('echo hello')
+  # A timeout may be specified with the :timeout_after option. The command will be
+  # sent the SIGKILL signal if it does not end before the specified timeout.
+  #
+  # @overload spawn_with_timeout(*command, **options_hash)
+  #
+  #   @param command [Array<String>] see [Process modulem, Argument `command_line` or `exe_path`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Argument+command_line)
+  #     and [Process module, Argument `args`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Arguments+args)
+  #
+  #     If the first value is a Hash, it is treated as the environment hash. See
+  #     [Process module, Execution Environment](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Execution+Environment).
+  #
+  #   @param options_hash [Hash] In addition to the options documented in [Process module, Execution Options](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Execution+Options),
+  #     the following options are supported: `:timeout_after`
+  #
+  #   @option options_hash [Numeric] :timeout_after the amount of time (in seconds) to
+  #     wait before signaling the process with SIGKILL
+  #
+  # @overload spawn_with_timeout(*command, options)
+  #
+  #   @param command [Array<String>] see [Process modulem, Argument `command_line` or `exe_path`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Argument+command_line)
+  #     and [Process module, Argument `args`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Arguments+args)
+  #
+  #     If the first value is a Hash, it is treated as the environment hash. See
+  #     [Process module, Execution Environment](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Execution+Environment).
+  #
+  #   @param options [ProcessExecuter::Options::SpawnWithTimeoutOptions]
+  #
+  # @example command line given as a single string
+  #   result = ProcessExecuter.spawn_with_timeout('echo "3\n2\n1" | sort')
   #   result.exited? # => true
   #   result.success? # => true
+  #   result.exitstatus # => 0
   #   result.timed_out? # => false
   #
+  # @example command given as an exe_path and args
+  #   result = ProcessExecuter.spawn_with_timeout('ping', '-c', '1', 'localhost')
+  #
   # @example with a timeout
-  #   result = ProcessExecuter.spawn_and_wait('sleep 10', timeout_after: 0.01)
+  #   result = ProcessExecuter.spawn_with_timeout('sleep 10', timeout_after: 0.01)
   #   result.exited? # => false
   #   result.success? # => nil
   #   result.signaled? # => true
   #   result.termsig # => 9
   #   result.timed_out? # => true
   #
-  # @example capturing stdout to a string
+  # @example with a env hash
+  #   env = { 'EXITSTATUS' => '1' }
+  #   result = ProcessExecuter.spawn_and_wait(env, 'exit $EXITSTATUS')
+  #   result.success? # => false
+  #   result.exitstatus # => 1
+  #
+  # @example capture stdout to a StringIO buffer
   #   stdout_buffer = StringIO.new
   #   stdout_pipe = ProcessExecuter::MonitoredPipe.new(stdout_buffer)
-  #   result = ProcessExecuter.spawn_and_wait('echo hello', out: stdout_pipe)
-  #   stdout_buffer.string # => "hello\n"
+  #   begin
+  #     result = ProcessExecuter.spawn_and_wait(env, 'echo "3\n2\n1" | sort', out: stdout_pipe)
+  #     stdout_buffer.string # => "1\n2\n3\n"
+  #   ensure
+  #     stdout_pipe.close
+  #   end
   #
-  # @see https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-spawn Kernel.spawn
-  #   documentation for valid command and options
+  # @raise [ProcessExecuter::SpawnError] If Process.spawn raises an error before the command is run
+  # @raise [ProcessExecuter::ArgumentError] If the command or an option is not valid
   #
-  # @see ProcessExecuter::Options#initialize ProcessExecuter::Options#initialize for
-  #   options that may be specified
+  # @return [ProcessExecuter::Result]
   #
-  # @param command [Array<String>] The command to execute
-  # @param options_hash [Hash] The options to use when executing the command
+  # @api public
   #
-  # @return [ProcessExecuter::Result] The result of the completed subprocess
-  #
-  def self.spawn_and_wait(*command, **options_hash)
-    options = ProcessExecuter.spawn_and_wait_options(options_hash)
-    spawn_and_wait_with_options(command, options)
-  end
+  def self.spawn_with_timeout(*command, **options_hash)
+    command, options = command_and_options(SpawnWithTimeoutOptions, command, options_hash)
 
-  # Run a command in a subprocess, wait for it to finish, then return the result
-  #
-  # @see ProcessExecuter.spawn_and_wait for full documentation
-  #
-  # @param command [Array<String>] The command to run
-  # @param options [ProcessExecuter::Options::SpawnAndWaitOptions] The options to use when running the command
-  #
-  # @return [ProcessExecuter::Result] The result of the completed subprocess
-  # @api private
-  def self.spawn_and_wait_with_options(command, options)
     begin
       pid = Process.spawn(*command, **options.spawn_options)
     rescue StandardError => e
       raise ProcessExecuter::SpawnError, "Failed to spawn process: #{e.message}"
     end
+
     wait_for_process(pid, command, options)
   end
 
-  # Execute the given command as a subprocess blocking until it finishes
+  # Wraps {spawn_with_timeout} adding more flexible redirection and other options
   #
-  # Works just like {ProcessExecuter.spawn}, but does the following in addition:
+  # This method wraps all option redirection destinations with a MonitoredPipe.
+  # Normally an output redirection destination must be a pipe. When the destination
+  # is wrapped by a MonitoredPipe, any object that implements #write can be given as
+  # a output redirection destination (such as StringIO which normally isn't allowed).
   #
-  #   1. If nothing is specified for `out`, stdout is captured to a `StringIO` object
-  #      which can be accessed via the Result object in `result.options.out`. The
-  #      same applies to `err`.
+  # Accepts the same options as {spawn_with_timeout} and adds the following options:
   #
-  #   2. `out` and `err` are automatically wrapped in a
-  #      `ProcessExecuter::MonitoredPipe` object so that any object that implements
-  #      `#write` (or an Array of such objects) can be given for `out` and `err`.
+  # * `:raise_errors` to make execution errors an exception (default is `true`)
+  # * `:logger` to log the command and its result at `:info` level.
   #
-  #   3. Raises one of the following errors unless `raise_errors` is explicitly set
-  #      to `false`:
+  # One of the following errors will be raised unless `raise_errors` is explicitly
+  # set to `false`:
   #
-  #      * `ProcessExecuter::FailedError` if the command returns a non-zero
-  #        exitstatus
-  #      * `ProcessExecuter::SignaledError` if the command exits because of
-  #        an unhandled signal
-  #      * `ProcessExecuter::TimeoutError` if the command times out
+  # * `ProcessExecuter::FailedError` if the command returns a non-zero
+  #   exitstatus
+  # * `ProcessExecuter::SignaledError` if the command exits because of
+  #   an unhandled signal
+  # * `ProcessExecuter::TimeoutError` if the command times out
   #
-  #      If `raise_errors` is false, the returned Result object will contain the error.
+  # If `raise_errors` is false and there was an error, the returned Result object
+  # indicate what the error .
   #
-  #   4. Raises a `ProcessExecuter::ProcessIOError` if an exception is raised
-  #      while collecting subprocess output. This can not be turned off.
+  # `ProcessExecuter::ProcessIOError` is raised if an exception is occurs while
+  # collecting subprocess output. The `raise_errors` option is ignored in this case.
   #
-  #   5. If a `logger` is provided, it will be used to log:
+  # If a `logger` is provided, it will be used to log:
   #
-  #      * The command that was executed and its status to `info` level
-  #      * The stdout and stderr output to `debug` level
+  # * The command that was executed and its status to `info` level
+  # * The stdout and stderr output to `debug` level
   #
-  #     By default, Logger.new(nil) is used for the logger.
+  # By default, Logger.new(nil) is used for the logger.
   #
-  # This method takes two forms:
+  # It is an error to give both options and options_hash.
   #
-  # 1. The command is executed via a shell when the command is given as a single
-  #    string:
-  #
-  #     `ProcessExecuter.run([env, ] command_line, options = {}) ->` {ProcessExecuter::Result}
-  #
-  # 2. The command is executed directly (bypassing the shell) when the command and it
-  #    arguments are given as an array of strings:
-  #
-  #     `ProcessExecuter.run([env, ] exe_path, *args, options = {}) ->` {ProcessExecuter::Result}
-  #
-  # Optional argument `env` is a hash that affects ENV for the new process; see
-  # [Execution
-  # Environment](https://docs.ruby-lang.org/en/3.3/Process.html#module-Process-label-Execution+Environment).
-  #
-  # Argument `options` is a hash of options for the new process. See the options listed below.
-  #
-  # @example Run a command given as a single string (uses shell)
-  #   # The command must be properly shell escaped when passed as a single string.
-  #   command = 'echo "stdout: `pwd`" && echo "stderr: $HOME" 1>&2'
-  #   result = ProcessExecuter.run(command)
-  #   result.success? #=> true
-  #   result.stdout #=> "stdout: /Users/james/projects/main-branch/process_executer\n"
-  #   result.stderr #=> "stderr: /Users/james\n"
-  #
-  # @example Run a command given as an array of strings (does not use shell)
-  #   # The command and its args must be provided as separate strings in the array.
-  #   # Shell expansions and redirections are not supported.
-  #   command = ['git', 'clone', 'https://github.com/main-branch/process_executer']
-  #   result = ProcessExecuter.run(*command)
-  #   result.success? #=> true
-  #   result.stdout #=> ""
-  #   result.stderr #=> "Cloning into 'process_executer'...\n"
-  #
-  # @example Run a command with a timeout
-  #   command = ['sleep', '1']
-  #   result = ProcessExecuter.run(*command, timeout_after: 0.01)
-  #   #=> raises ProcessExecuter::TimeoutError which contains the command result
-  #
-  # @example Run a command which fails
-  #   command = ['exit 1']
-  #   result = ProcessExecuter.run(*command)
-  #   #=> raises ProcessExecuter::FailedError which contains the command result
-  #
-  # @example Run a command which exits due to an unhandled signal
-  #   command = ['kill -9 $$']
-  #   result = ProcessExecuter.run(*command)
-  #   #=> raises ProcessExecuter::SignaledError which contains the command result
-  #
-  # @example Do not raise an error when the command fails
-  #   command = ['echo "Some error" 1>&2 && exit 1']
-  #   result = ProcessExecuter.run(*command, raise_errors: false)
-  #   result.success? #=> false
-  #   result.exitstatus #=> 1
-  #   result.stdout #=> ""
-  #   result.stderr #=> "Some error\n"
-  #
-  # @example Set environment variables
-  #   env = { 'FOO' => 'foo', 'BAR' => 'bar' }
-  #   command = 'echo "$FOO$BAR"'
-  #   result = ProcessExecuter.run(env, *command)
-  #   result.stdout #=> "foobar\n"
-  #
-  # @example Set environment variables when using a command array
-  #   env = { 'FOO' => 'foo', 'BAR' => 'bar' }
-  #   command = ['ruby', '-e', 'puts ENV["FOO"] + ENV["BAR"]']
-  #   result = ProcessExecuter.run(env, *command)
-  #   result.stdout #=> "foobar\n"
-  #
-  # @example Unset environment variables
-  #   env = { 'FOO' => nil } # setting to nil unsets the variable in the environment
-  #   command = ['echo "FOO: $FOO"']
-  #   result = ProcessExecuter.run(env, *command)
-  #   result.stdout #=> "FOO: \n"
-  #
-  # @example Reset existing environment variables and add new ones
-  #   env = { 'PATH' => '/bin' }
-  #   result = ProcessExecuter.run(env, 'echo "Home: $HOME" && echo "Path: $PATH"', unsetenv_others: true)
-  #   result.stdout #=> "Home: \n/Path: /bin\n"
-  #
-  # @example Run command in a different directory
-  #   command = ['pwd']
-  #   result = ProcessExecuter.run(*command, chdir: '/tmp')
-  #   result.stdout #=> "/tmp\n"
-  #
-  # @example Capture stdout and stderr into a single buffer
-  #   command = ['echo "stdout" && echo "stderr" 1>&2']
-  #   result = ProcessExecuter.run(*command, [out:, err:]: StringIO.new)
-  #   result.stdout #=> "stdout\nstderr\n"
-  #   result.stderr #=> "stdout\nstderr\n"
-  #   result.stdout.object_id == result.stderr.object_id #=> true
-  #
-  # @example Capture to an explicit buffer
-  #   out = StringIO.new
-  #   err = StringIO.new
-  #   command = ['echo "stdout" && echo "stderr" 1>&2']
-  #   result = ProcessExecuter.run(*command, out: out, err: err)
-  #   out.string #=> "stdout\n"
-  #   err.string #=> "stderr\n"
-  #
-  # @example Capture to a file
-  #   # Same technique can be used for stderr
-  #   out = File.open('stdout.txt', 'w')
-  #   err = StringIO.new
-  #   command = ['echo "stdout" && echo "stderr" 1>&2']
-  #   result = ProcessExecuter.run(*command, out: out, err: err)
-  #   out.close
-  #   File.read('stdout.txt') #=> "stdout\n"
-  #   # stderr is still captured to a StringIO buffer internally
-  #   result.stderr #=> "stderr\n"
-  #
-  # @example Capture to multiple destinations (e.g. files, buffers, STDOUT, etc.)
-  #   # Same technique can be used for stderr
+  # @example capture stdout to a StringIO buffer
   #   out_buffer = StringIO.new
-  #   out_file = File.open('stdout.txt', 'w')
-  #   command = ['echo "stdout" && echo "stderr" 1>&2']
-  #   result = ProcessExecuter.run(*command, out: [:tee, out_buffer, out_file])
-  #   # You must manage closing resources you create yourself
-  #   out_file.close
-  #   out_buffer.string #=> "stdout\n"
-  #   File.read('stdout.txt') #=> "stdout\n"
-  #   result.stdout #=> "stdout\n"
+  #   result = ProcessExecuter.run('echo HELLO', out: out_buffer)
+  #   out_buffer.string #=> "HELLO\n"
   #
-  # @param command [Array<String>] The command to run
+  # @example with :raise_errors set to true
+  #   begin
+  #     result = ProcessExecuter.run('exit 1', raise_errors: true)
+  #   rescue ProcessExecuter::FailedError => e
+  #     e.result.exitstatus #=> 1
+  #   end
   #
-  #   If the first element of command is a Hash, it is added to the ENV of
-  #   the new process. See [Execution Environment](https://ruby-doc.org/3.3.6/Process.html#module-Process-label-Execution+Environment)
-  #   for more details. The env hash is then removed from the command array.
+  # @example with :raise_errors set to false
+  #   result = ProcessExecuter.run('exit 1', raise_errors: false)
+  #   result.exitstatus #=> 1
   #
-  #   If the first and only (remaining) command element is a string, it is passed to
-  #   a subshell if it begins with a shell reserved word, contains special built-ins,
-  #   or includes shell metacharacters.
+  # @example with a logger
+  #   logger_buffer = StringIO.new
+  #   logger = Logger.new(logger_buffer, level: :info)
+  #   result = ProcessExecuter.run('echo HELLO', logger: logger)
+  #   logger_buffer.string #=>
+  #     "INFO -- : Running command: echo HELLO\nDEUBG -- : Command completed with exit status 0\n"
   #
-  #   Care must be taken to properly escape shell metacharacters in the command string.
+  # @overload run(*command, **options_hash)
   #
-  #   Otherwise, the command is run bypassing the shell. When bypassing the shell, shell expansions
-  #   and redirections are not supported.
+  #   @param command [Array<String>] see [Process modulem, Argument `command_line` or `exe_path`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Argument+command_line)
+  #     and [Process module, Argument `args`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Arguments+args)
   #
-  # @param options_hash [Hash] Additional options
-  # @option options_hash [Numeric] :timeout_after The maximum seconds to wait for the
-  #   command to complete
+  #     If the first value is a Hash, it is treated as the environment hash. See
+  #     [Process module, Execution Environment](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Execution+Environment).
   #
-  #     If zero or nil, the command will not time out. If the command
-  #     times out, it is killed via a SIGKILL signal. A {ProcessExecuter::TimeoutError}
-  #     will be raised if the `:raise_errors` option is true.
+  #   @param [Hash] options_hash in addition to the options supported by
+  #     {spawn_with_timeout}, the following options may be given: `:raise_errors` and `:logger`
   #
-  #     If the command does not exit when receiving the SIGKILL signal, this method may hang indefinitely.
+  #   @option options_hash [Boolean] :raise_errors if true, an error will be raised if the command fails
   #
-  # @option options_hash [#write] :out (nil) The object to write stdout to
-  # @option options_hash [#write] :err (nil) The object to write stderr to
-  # @option options_hash [Boolean] :raise_errors (true) Raise an exception if the command fails
-  # @option options_hash [Boolean] :unsetenv_others (false) If true, unset all environment variables before
-  #   applying the new ones
-  # @option options_hash [true, Integer, nil] :pgroup (nil) true or 0: new process group; non-zero: join
-  #   the group, nil: existing group
-  # @option options_hash [Boolean] :new_pgroup (nil) Create a new process group (Windows only)
-  # @option options_hash [Integer] :rlimit_resource_name (nil) Set resource limits (see Process.setrlimit)
-  # @option options_hash [Integer] :umask (nil) Set the umask (see File.umask)
-  # @option options_hash [Boolean] :close_others (false) If true, close non-standard file descriptors
-  # @option options_hash [String] :chdir (nil) The directory to run the command in
-  # @option options_hash [Logger] :logger The logger to use
+  #   @option options_hash [Logger] :logger a logger to use for logging the command and its result at the info level
   #
-  # @raise [ProcessExecuter::Error] if the command could not be executed or failed
+  #   @option options_hash [Numeric] :timeout_after the amount of time (in seconds) to
+  #     wait before signaling the process with SIGKILL
   #
-  # @return [ProcessExecuter::Result] The result of the completed subprocess
+  # @overload run(*command, options)
+  #
+  #   @param command [Array<String>] see [Process modulem, Argument `command_line` or `exe_path`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Argument+command_line)
+  #     and [Process module, Argument `args`](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Arguments+args)
+  #
+  #     If the first value is a Hash, it is treated as the environment hash. See
+  #     [Process module, Execution Environment](https://docs.ruby-lang.org/en/3.4/Process.html#module-Process-label-Execution+Environment).
+  #
+  #   @param options [ProcessExecuter::Options::RunOptions]
+  #
+  # @raise [ProcessExecuter::SpawnError] If spawn raises an error before the command is run
+  # @raise [ProcessExecuter::ArgumentError] If the command or an option is not valid
+  # @raise [ProcessExecuter::FailedError] If the command runs and returns a non-zero exit code
+  # @raise [ProcessExecuter::SignaledError] If the command runs and exits because of an uncaught signal
+  # @raise [ProcessExecuter::TimeoutError] If the command runs and takes longer than the configured timeout_after
+  # @raise [ProcessExecuter::ProcessIOError] If the command runs and the output can not be read
+  #
+  # @return [ProcessExecuter::Result]
+  #
+  # @api public
   #
   def self.run(*command, **options_hash)
-    options = ProcessExecuter.run_options(options_hash)
-    run_with_options(command, options)
-  end
-
-  # Run a command with the given options
-  #
-  # @see ProcessExecuter.run for full documentation
-  #
-  # @param command [Array<String>] The command to run
-  # @param options [ProcessExecuter::Options::RunOptions] The options to use when running the command
-  #
-  # @return [ProcessExecuter::Result] The result of the completed subprocess
-  #
-  # @api private
-  def self.run_with_options(command, options)
+    command, options = command_and_options(RunOptions, command, options_hash)
     ProcessExecuter::Runner.new.call(command, options)
   end
 
@@ -355,87 +268,56 @@ module ProcessExecuter
     [process_status, timed_out]
   end
 
-  # Convert a hash to a SpawnOptions object
+  # Takes a comamnd and options_hash to determine the options object
   #
-  # @example
+  # To support either passing an options object or an options_hash, this method
+  # takes a command and an options_hash and returns the command (with the trailing
+  # options object removed if one is given) and and options object.
+  #
+  # @example options hash not empty
+  #   SpawnWithTimeoutOptions = ProcessExecuter::Options::SpawnWithTimeoutOptions
+  #   command = %w[echo hello]
   #   options_hash = { out: $stdout }
-  #   options = ProcessExecuter.spawn_options(options_hash) # =>
-  #     #<ProcessExecuter::Options::SpawnOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #   ProcessExecuter.spawn_options(options) # =>
-  #     #<ProcessExecuter::Options::SpawnOptions:0x00007f8f9b0b3d20 out: $stdout>
+  #   command_out, options_out = ProcessExecuter.command_and_options(SpawnWithTimeoutOptions, command, options_hash)
+  #   command_out #=> %w[echo hello]
+  #   options_out #=> an options_class instance initialized with the options_hash
   #
-  # @param obj [Hash, SpawnOptions] the object to be converted
+  # @example option hash empty, command DOES NOT end with an options object
+  #   SpawnWithTimeoutOptions = ProcessExecuter::Options::SpawnWithTimeoutOptions
+  #   command = %w[echo hello]
+  #   options_hash = {}
+  #   command_out, options_out = ProcessExecuter.command_and_options(SpawnWithTimeoutOptions, command, options_hash)
+  #   command_out #=> %w[echo hello]
+  #   options_out #=> # options_class instance with all default values is returned
   #
-  # @return [SpawnOptions]
+  # @example options_hash empty, command ends with an options object
+  #   SpawnWithTimeoutOptions = ProcessExecuter::Options::SpawnWithTimeoutOptions
+  #   options = ProcessExecuter::Options::SpawnWithTimeoutOptions.new(out: $stdout)
+  #   command = ['echo', 'hello', options]
+  #   options_hash = {}
+  #   command_out, options_out = ProcessExecuter.spawn_and_wait_options(command, options_hash)
+  #   command_out #=> %w[echo hello] # options removed from command
+  #   options_out #=> what was previously command[-1]
   #
-  # @raise [ArgumentError] if obj is not a Hash or SpawnOptions
+  # @param options_class [Class] the class of the options object
+  #
+  # @param command [Array] the command to be executed (possibly with an instance of
+  #   options_class at the end)
+  #
+  # @param options_hash [Hash] the (possibly empty) hash of options
+  #
+  # @return [Array, options_class] the command (possible with the options
+  #   removed) and an instance of options_class
   #
   # @api public
   #
-  def self.spawn_options(obj)
-    case obj
-    when ProcessExecuter::Options::SpawnOptions
-      obj
-    when Hash
-      ProcessExecuter::Options::SpawnOptions.new(**obj)
+  def self.command_and_options(options_class, command, options_hash)
+    if !options_hash.empty?
+      [command, options_class.new(**options_hash)]
+    elsif command[-1].is_a?(options_class)
+      [command[..-2], command[-1]]
     else
-      raise ArgumentError, "Expected a Hash or ProcessExecuter::Options::SpawnOptions but got a #{obj.class}"
-    end
-  end
-
-  # Convert a hash to a SpawnAndWaitOptions object
-  #
-  # @example
-  #   options_hash = { out: $stdout }
-  #   options = ProcessExecuter.spawn_and_wait_options(options_hash) # =>
-  #     #<ProcessExecuter::Options::SpawnAndWaitOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #   ProcessExecuter.spawn_and_wait_options(options) # =>
-  #     #<ProcessExecuter::Options::SpawnAndWaitOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #
-  # @param obj [Hash, SpawnAndWaitOptions] the object to be converted
-  #
-  # @return [SpawnAndWaitOptions]
-  #
-  # @raise [ArgumentError] if obj is not a Hash or SpawnOptions
-  #
-  # @api public
-  #
-  def self.spawn_and_wait_options(obj)
-    case obj
-    when ProcessExecuter::Options::SpawnAndWaitOptions
-      obj
-    when Hash
-      ProcessExecuter::Options::SpawnAndWaitOptions.new(**obj)
-    else
-      raise ArgumentError, "Expected a Hash or ProcessExecuter::Options::SpawnAndWaitOptions but got a #{obj.class}"
-    end
-  end
-
-  # Convert a hash to a RunOptions object
-  #
-  # @example
-  #   options_hash = { out: $stdout }
-  #   options = ProcessExecuter.run_options(options_hash) # =>
-  #     #<ProcessExecuter::Options::RunOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #   ProcessExecuter.run_options(options) # =>
-  #     #<ProcessExecuter::Options::RunOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #
-  # @param obj [Hash, RunOptions] the object to be converted
-  #
-  # @return [RunOptions]
-  #
-  # @raise [ArgumentError] if obj is not a Hash or SpawnOptions
-  #
-  # @api public
-  #
-  def self.run_options(obj)
-    case obj
-    when ProcessExecuter::Options::RunOptions
-      obj
-    when Hash
-      ProcessExecuter::Options::RunOptions.new(**obj)
-    else
-      raise ArgumentError, "Expected a Hash or ProcessExecuter::Options::RunOptions but got a #{obj.class}"
+      [command, options_class.new]
     end
   end
 end

--- a/lib/process_executer/destination_base.rb
+++ b/lib/process_executer/destination_base.rb
@@ -14,24 +14,12 @@ module ProcessExecuter
     # @return [DestinationBase] a new destination handler instance
     def initialize(destination)
       @destination = destination
-      @data_written = []
     end
 
     # The destination object this handler manages
     #
     # @return [Object] the destination object
     attr_reader :destination
-
-    # The data written to the destination
-    #
-    # @return [Array<String>] the data written to the destination
-    attr_reader :data_written
-
-    # The data written to the destination as a single string
-    # @return [String]
-    def string
-      data_written.join
-    end
 
     # Writes data to the destination
     #
@@ -40,9 +28,7 @@ module ProcessExecuter
     # @param data [String] the data to write
     # @return [void]
     # @raise [NotImplementedError] if the subclass doesn't implement this method
-    def write(data)
-      @data_written << data
-    end
+    def write(data); end
 
     # Closes the destination if necessary
     #

--- a/lib/process_executer/destinations/writer.rb
+++ b/lib/process_executer/destinations/writer.rb
@@ -23,6 +23,9 @@ module ProcessExecuter
 
       # Determines if this class can handle the given destination
       #
+      # Don't answer true if the destination has a file descriptor so it can be
+      # handled by the IO class.
+      #
       # @param destination [Object] the destination to check
       # @return [Boolean] true if destination responds to write but is not an IO with fileno
       def self.handles?(destination)

--- a/lib/process_executer/errors.rb
+++ b/lib/process_executer/errors.rb
@@ -13,6 +13,7 @@ module ProcessExecuter
   # ```text
   # ::StandardError
   #   └─> Error
+  #       ├─> ArgumentError
   #       ├─> CommandError
   #       │   ├─> FailedError
   #       │   └─> SignaledError
@@ -24,6 +25,7 @@ module ProcessExecuter
   # | Error Class | Description |
   # | --- | --- |
   # | `Error` | This catch-all error serves as the base class for other custom errors. |
+  # | `ArgumentError` | Raised when an invalid argument is passed to a method. |
   # | `CommandError` | A subclass of this error is raised when there is a problem executing a command. |
   # | `FailedError` | Raised when the command exits with a non-zero status code. |
   # | `SignaledError` | Raised when the command is terminated as a result of receiving a signal. This could happen if the process is forcibly terminated or if there is a serious system error. |
@@ -51,6 +53,18 @@ module ProcessExecuter
   # @api public
   #
   class Error < ::StandardError; end
+
+  # Raised when an invalid argument is passed to a method
+  #
+  # @example
+  #   begin
+  #     # Command should not be an array
+  #     ProcessExecuter.run(nil, timeout_after: -1)
+  #   rescue ProcessExecuter::ArgumentError => e
+  #     e.message #=> "Command elements must be a String"
+  #   end
+  #
+  class ArgumentError < ProcessExecuter::Error; end
 
   # Raised when a command fails or exits because of an uncaught signal
   #
@@ -90,7 +104,7 @@ module ProcessExecuter
     # @return [String]
     #
     def error_message
-      "#{result.command}, status: #{result}, stderr: #{result.stderr.inspect}"
+      "#{result.command}, status: #{result}"
     end
 
     # @attribute [r] result

--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -2,7 +2,7 @@
 
 require_relative 'options/base'
 require_relative 'options/spawn_options'
-require_relative 'options/spawn_and_wait_options'
+require_relative 'options/spawn_with_timeout_options'
 require_relative 'options/run_options'
 require_relative 'options/option_definition'
 

--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -133,7 +133,7 @@ module ProcessExecuter
       #   options.option1 # => 'value1'
       #   options.option2 # => 'value2'
       #
-      # @options_hash [Hash] the options to merge into the current options
+      # @param options_hash [Hash] the options to merge into the current options
       # @return [self.class]
       #
       def with(**options_hash)
@@ -197,7 +197,7 @@ module ProcessExecuter
 
       # Raise an argument error for invalid option values
       # @return [void]
-      # @raise [ArgumentError] if any invalid option values are found
+      # @raise [ProcessExecuter::ArgumentError] if any invalid option values are found
       # @api private
       def validate_options
         options.each_key do |option_key|
@@ -205,7 +205,7 @@ module ProcessExecuter
           instance_exec(&validator.to_proc) unless validator.nil?
         end
 
-        raise ArgumentError, errors.join("\n") unless errors.empty?
+        raise ProcessExecuter::ArgumentError, errors.join("\n") unless errors.empty?
       end
 
       # Define accessor methods for each option
@@ -221,19 +221,17 @@ module ProcessExecuter
 
       # Determine if the options hash contains any unknown options
       # @return [void]
-      # @raise [ArgumentError] if the options hash contains any unknown options
+      # @raise [ProcessExecuter::ArgumentError] if the options hash contains any unknown options
       # @api private
       def assert_no_unknown_options
         unknown_options = options.keys.reject { |key| valid_option?(key) }
 
         return if unknown_options.empty?
 
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
         raise(
-          ArgumentError,
+          ProcessExecuter::ArgumentError,
           "Unknown option#{unknown_options.count > 1 ? 's' : ''}: #{unknown_options.join(', ')}"
         )
-        # :nocov:
       end
     end
   end

--- a/lib/process_executer/options/run_options.rb
+++ b/lib/process_executer/options/run_options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'spawn_and_wait_options'
+require_relative 'spawn_with_timeout_options'
 require_relative 'option_definition'
 
 module ProcessExecuter
@@ -9,10 +9,8 @@ module ProcessExecuter
     #
     # @api public
     #
-    class RunOptions < SpawnAndWaitOptions
+    class RunOptions < SpawnWithTimeoutOptions
       private
-
-      # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
 
       # The options allowed for objects of this class
       # @return [Array<OptionDefinition>]
@@ -24,7 +22,6 @@ module ProcessExecuter
           OptionDefinition.new(:logger, default: Logger.new(nil), validator: method(:validate_logger))
         ].freeze
       end
-      # :nocov:
 
       # Validate the raise_errors option value
       # @return [String, nil] the error message if the value is not valid

--- a/lib/process_executer/options/spawn_options.rb
+++ b/lib/process_executer/options/spawn_options.rb
@@ -14,7 +14,7 @@ module ProcessExecuter
     # @api public
     #
     class SpawnOptions < Base
-      # :nocov: SimpleCov on JRuby reports hashes declared on multiple lines as not covered
+      # The allowed options for Process.spawn
       SPAWN_OPTIONS = [
         OptionDefinition.new(:unsetenv_others, default: :not_set),
         OptionDefinition.new(:pgroup, default: :not_set),
@@ -24,7 +24,6 @@ module ProcessExecuter
         OptionDefinition.new(:close_others, default: :not_set),
         OptionDefinition.new(:chdir, default: :not_set)
       ].freeze
-      # :nocov:
 
       # Returns the options to be passed to Process.spawn
       #
@@ -68,19 +67,19 @@ module ProcessExecuter
       # @api private
       def stdout_redirection?(option_key) = std_redirection?(option_key, :out, 1)
 
-      # Determine the option key that indicates a redirection option for stdout
-      # @return [Symbol, Integer, IO, Array, nil] nil if not found
-      # @api private
-      def stdout_redirection_key
-        options.keys.find { |option_key| option_key if stdout_redirection?(option_key) }
-      end
+      # # Determine the option key that indicates a redirection option for stdout
+      # # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # # @api private
+      # def stdout_redirection_key
+      #   options.keys.find { |option_key| option_key if stdout_redirection?(option_key) }
+      # end
 
-      # Determine the value of the redirection option for stdout
-      # @return [Object]
-      # @api private
-      def stdout_redirection_value
-        options[stdout_redirection_key]
-      end
+      # # Determine the value of the redirection option for stdout
+      # # @return [Object]
+      # # @api private
+      # def stdout_redirection_value
+      #   options[stdout_redirection_key]
+      # end
 
       # Determine if the given option key indicates a redirection option for stderr
       # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
@@ -88,19 +87,19 @@ module ProcessExecuter
       # @api private
       def stderr_redirection?(option_key) = std_redirection?(option_key, :err, 2)
 
-      # Determine the option key that indicates a redirection option for stderr
-      # @return [Symbol, Integer, IO, Array, nil] nil if not found
-      # @api private
-      def stderr_redirection_key
-        options.keys.find { |option_key| option_key if stderr_redirection?(option_key) }
-      end
+      # # Determine the option key that indicates a redirection option for stderr
+      # # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # # @api private
+      # def stderr_redirection_key
+      #   options.keys.find { |option_key| option_key if stderr_redirection?(option_key) }
+      # end
 
-      # Determine the value of the redirection option for stderr
-      # @return [Object]
-      # @api private
-      def stderr_redirection_value
-        options[stderr_redirection_key]
-      end
+      # # Determine the value of the redirection option for stderr
+      # # @return [Object]
+      # # @api private
+      # def stderr_redirection_value
+      #   options[stderr_redirection_key]
+      # end
 
       private
 

--- a/lib/process_executer/options/spawn_with_timeout_options.rb
+++ b/lib/process_executer/options/spawn_with_timeout_options.rb
@@ -9,19 +9,17 @@ module ProcessExecuter
     #
     # @api public
     #
-    class SpawnAndWaitOptions < SpawnOptions
+    class SpawnWithTimeoutOptions < SpawnOptions
       private
 
       # The options allowed for objects of this class
       # @return [Array<OptionDefinition>]
       # @api private
       def define_options
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
         [
           *super,
           OptionDefinition.new(:timeout_after, default: nil, validator: method(:validate_timeout_after))
         ].freeze
-        # :nocov:
       end
 
       # Raise an error unless timeout_after is nil or a non-negative real number

--- a/lib/process_executer/result.rb
+++ b/lib/process_executer/result.rb
@@ -8,8 +8,6 @@ module ProcessExecuter
   # * `command`: the command that was used to spawn the process
   # * `options`: the options that were used to spawn the process
   # * `elapsed_time`: the secs the command ran
-  # * `stdout`: the captured stdout output
-  # * `stderr`: the captured stderr output
   # * `timed_out?`: true if the process timed out
   #
   # @api public
@@ -105,46 +103,6 @@ module ProcessExecuter
     # @return [String]
     def to_s
       "#{super}#{timed_out? ? " timed out after #{options.timeout_after}s" : ''}"
-    end
-
-    # Return the captured stdout output
-    #
-    # This output is only returned if the `:out` option value is a
-    # `ProcessExecuter::MonitoredPipe`.
-    #
-    # @example
-    #   # Note that `ProcessExecuter.run` will wrap the given out: object in a
-    #   # ProcessExecuter::MonitoredPipe
-    #   result = ProcessExecuter.run('echo hello': out: StringIO.new)
-    #   result.stdout #=> "hello\n"
-    #
-    # @return [String, nil]
-    #
-    def stdout
-      pipe = options.stdout_redirection_value
-      return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
-
-      pipe.destination.string
-    end
-
-    # Return the captured stderr output
-    #
-    # This output is only returned if the `:err` option value is a
-    # `ProcessExecuter::MonitoredPipe`.
-    #
-    # @example
-    #   # Note that `ProcessExecuter.run` will wrap the given err: object in a
-    #   # ProcessExecuter::MonitoredPipe
-    #   result = ProcessExecuter.run('echo ERROR 1>&2', err: StringIO.new)
-    #   resuilt.stderr #=> "ERROR\n"
-    #
-    # @return [String, nil]
-    #
-    def stderr
-      pipe = options.stderr_redirection_value
-      return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
-
-      pipe.destination.string
     end
   end
 end

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -50,7 +50,7 @@ module ProcessExecuter
     #
     def spawn(command, options)
       opened_pipes = wrap_stdout_stderr(options)
-      ProcessExecuter.spawn_and_wait_with_options(command, options)
+      ProcessExecuter.spawn_with_timeout(*command, options)
     ensure
       opened_pipes.each_value(&:close)
       opened_pipes.each { |option_key, pipe| raise_pipe_error(command, option_key, pipe) }
@@ -119,7 +119,6 @@ module ProcessExecuter
     # @api private
     def log_result(result)
       result.options.logger.info { "#{result.command} exited with status #{result}" }
-      result.options.logger.debug { "stdout:\n#{result.stdout.inspect}\nstderr:\n#{result.stderr.inspect}" }
     end
 
     # Raise an error when there was exception while collecting the subprocess output

--- a/spec/process_executer/destination_base_spec.rb
+++ b/spec/process_executer/destination_base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe ProcessExecuter::DestinationBase do
+  describe '.handles?' do
+    it 'raises NotImplementedError' do
+      expect { described_class.handles?('destination') }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/process_executer/destinations_spec.rb
+++ b/spec/process_executer/destinations_spec.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe ProcessExecuter::DestinationBase do
-  describe '.handles?' do
-    it 'raises NotImplementedError' do
-      expect { described_class.handles?('destination') }.to raise_error(NotImplementedError)
+RSpec.describe ProcessExecuter::Destinations do
+  describe '.compatible_with_monitored_pipe?' do
+    subject { described_class.compatible_with_monitored_pipe?(destination) }
+    context 'when the destination is not valid' do
+      let(:destination) { Object.new }
+      it 'should raise a ProcessExecuter::ArgumentError' do
+        expect { subject }.to(
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
+        )
+      end
     end
   end
 end

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
     context 'when the output destination is nil' do
       let(:destination) { nil }
       it 'should raise an ArgumentError' do
-        expect { ProcessExecuter::MonitoredPipe.new(nil) }.to raise_error(ArgumentError, 'wrong exec redirect action')
+        expect { ProcessExecuter::MonitoredPipe.new(nil) }.to(
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
+        )
       end
     end
 
@@ -162,7 +164,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # [filepath] only works for stdin
       it 'should raise an ArgumentError' do
         expect { ProcessExecuter::MonitoredPipe.new(['filepath']) }.to(
-          raise_error(ArgumentError, 'wrong exec redirect action')
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
         )
       end
     end
@@ -421,7 +423,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # redirect the source to the destination fd in the child process
       it 'should raise an error' do
         expect { ProcessExecuter::MonitoredPipe.new([:child, 1]) }.to(
-          raise_error(ArgumentError, 'Destination [:child, 1] is not compatible with MonitoredPipe')
+          raise_error(ProcessExecuter::ArgumentError, 'Destination [:child, 1] is not compatible with MonitoredPipe')
         )
       end
     end
@@ -430,7 +432,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
       # close the fd in the child process
       it 'should raise an error' do
         expect { ProcessExecuter::MonitoredPipe.new(:close) }.to(
-          raise_error(ArgumentError, 'wrong exec redirect action')
+          raise_error(ProcessExecuter::ArgumentError, 'Destination close is not compatible with MonitoredPipe')
         )
       end
     end

--- a/spec/process_executer/options/base_spec.rb
+++ b/spec/process_executer/options/base_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe ProcessExecuter::Options::Base do
     context 'when a single unknown option is given' do
       let(:options_hash) { { unknown: true } }
       it 'should raise an error' do
-        expect { options }.to raise_error(ArgumentError, 'Unknown option: unknown')
+        expect { options }.to raise_error(ProcessExecuter::ArgumentError, 'Unknown option: unknown')
       end
     end
 
     context 'when multiple unknown options are given' do
       let(:options_hash) { { unknown1: true, unknown2: false } }
       it 'should raise an error' do
-        expect { options }.to raise_error(ArgumentError, 'Unknown options: unknown1, unknown2')
+        expect { options }.to raise_error(ProcessExecuter::ArgumentError, 'Unknown options: unknown1, unknown2')
       end
     end
   end
@@ -326,7 +326,7 @@ RSpec.describe ProcessExecuter::Options::Base do
           let(:options_hash) { { option1: 123, option2: 2 } }
 
           it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, 'option1 must be a String')
+            expect { subject }.to raise_error(ProcessExecuter::ArgumentError, 'option1 must be a String')
           end
         end
 
@@ -334,7 +334,7 @@ RSpec.describe ProcessExecuter::Options::Base do
           let(:options_hash) { { option1: 'value1', option2: 'invalid' } }
 
           it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, 'option2 must be an Integer')
+            expect { subject }.to raise_error(ProcessExecuter::ArgumentError, 'option2 must be an Integer')
           end
         end
 
@@ -342,7 +342,9 @@ RSpec.describe ProcessExecuter::Options::Base do
           let(:options_hash) { { option1: 123, option2: 'invalid' } }
 
           it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, "option1 must be a String\noption2 must be an Integer")
+            expect do
+              subject
+            end.to raise_error(ProcessExecuter::ArgumentError, "option1 must be a String\noption2 must be an Integer")
           end
         end
       end

--- a/spec/process_executer/options/run_options_spec.rb
+++ b/spec/process_executer/options/run_options_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
       it 'should raise an error' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was -1'
           )
         )
@@ -62,7 +62,7 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
       it 'should raise an error' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'logger must respond to #info and #debug but was "invalid"'
           )
         )
@@ -83,7 +83,7 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
       it 'should raise an error' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'raise_errors must be true or false but was nil'
           )
         )
@@ -104,7 +104,7 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
       it 'should raise an error' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was "invalid"'
           )
         )

--- a/spec/process_executer/options/spawn_and_wait_options_spec.rb
+++ b/spec/process_executer/options/spawn_and_wait_options_spec.rb
@@ -2,7 +2,7 @@
 
 require 'stringio'
 
-RSpec.describe ProcessExecuter::Options::SpawnAndWaitOptions do
+RSpec.describe ProcessExecuter::Options::SpawnWithTimeoutOptions do
   let(:options) { described_class.new(**options_hash) }
   let(:options_hash) { {} }
 
@@ -46,7 +46,7 @@ RSpec.describe ProcessExecuter::Options::SpawnAndWaitOptions do
       it 'should raise an error' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was "invalid"'
           )
         )

--- a/spec/process_executer/options/spawn_options_spec.rb
+++ b/spec/process_executer/options/spawn_options_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe ProcessExecuter::Options::SpawnOptions do
 
     context 'when an unknown option is given' do
       it 'should raise an ArgumentError' do
-        expect { described_class.new(unknown: true) }.to raise_error(ArgumentError, 'Unknown option: unknown')
+        expect { described_class.new(unknown: true) }.to(
+          raise_error(ProcessExecuter::ArgumentError, 'Unknown option: unknown')
+        )
       end
     end
   end

--- a/spec/process_executer/options_conversions_spec.rb
+++ b/spec/process_executer/options_conversions_spec.rb
@@ -1,81 +1,83 @@
 # frozen_string_literal: true
 
-RSpec.describe ProcessExecuter do
-  describe '.spawn_options' do
-    subject { ProcessExecuter.spawn_options(given_options) }
+# # frozen_string_literal: true
 
-    context 'when given options is a Hash' do
-      let(:given_options) { { out: $stdout } }
-      it 'should return a SpawnOptions object with the same options' do
-        expect(subject).to be_a(ProcessExecuter::Options::SpawnOptions)
-        expect(subject.to_h).to include(given_options)
-      end
-    end
+# RSpec.describe ProcessExecuter do
+#   describe '.spawn_options' do
+#     subject { ProcessExecuter.spawn_options(given_options) }
 
-    context 'when given options is a ProcessExecuter::Options::SpawnOptions' do
-      let(:given_options) { ProcessExecuter::Options::SpawnOptions.new(out: $stdout) }
-      it 'should return the given object' do
-        expect(subject.object_id).to eq(given_options.object_id)
-      end
-    end
+#     context 'when given options is a Hash' do
+#       let(:given_options) { { out: $stdout } }
+#       it 'should return a SpawnOptions object with the same options' do
+#         expect(subject).to be_a(ProcessExecuter::Options::SpawnOptions)
+#         expect(subject.to_h).to include(given_options)
+#       end
+#     end
 
-    context 'when given options any other kind of option' do
-      let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-  end
+#     context 'when given options is a ProcessExecuter::Options::SpawnOptions' do
+#       let(:given_options) { ProcessExecuter::Options::SpawnOptions.new(out: $stdout) }
+#       it 'should return the given object' do
+#         expect(subject.object_id).to eq(given_options.object_id)
+#       end
+#     end
 
-  describe '.spawn_and_wait_options' do
-    subject { ProcessExecuter.spawn_and_wait_options(given_options) }
+#     context 'when given options any other kind of option' do
+#       let(:given_options) { Object.new }
+#       it 'should raise an ProcessExecuter::ArgumentError' do
+#         expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
+#       end
+#     end
+#   end
 
-    context 'when given options is a Hash' do
-      let(:given_options) { { timeout_after: 10 } }
-      it 'should return a SpawnAndWaitOptions object with the same options' do
-        expect(subject).to be_a(ProcessExecuter::Options::SpawnAndWaitOptions)
-        expect(subject.to_h).to include(given_options)
-      end
-    end
+#   describe '.spawn_and_wait_options' do
+#     subject { ProcessExecuter.spawn_with_timeout_options(given_options) }
 
-    context 'when given options is a ProcessExecuter::Options::SpawnAndWaitOptions' do
-      let(:given_options) { ProcessExecuter::Options::SpawnAndWaitOptions.new(timeout_after: 10) }
-      it 'should return the given object' do
-        expect(subject.object_id).to eq(given_options.object_id)
-      end
-    end
+#     context 'when given options is a Hash' do
+#       let(:given_options) { { timeout_after: 10 } }
+#       it 'should return a SpawnWithTimeoutOptions object with the same options' do
+#         expect(subject).to be_a(ProcessExecuter::Options::SpawnWithTimeoutOptions)
+#         expect(subject.to_h).to include(given_options)
+#       end
+#     end
 
-    context 'when given options any other kind of option' do
-      let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-  end
+#     context 'when given options is a ProcessExecuter::Options::SpawnAndWaitOptions' do
+#       let(:given_options) { ProcessExecuter::Options::SpawnAndWaitOptions.new(timeout_after: 10) }
+#       it 'should return the given object' do
+#         expect(subject.object_id).to eq(given_options.object_id)
+#       end
+#     end
 
-  describe '.run_options' do
-    subject { ProcessExecuter.run_options(given_options) }
+#     context 'when given options any other kind of option' do
+#       let(:given_options) { Object.new }
+#       it 'should raise an ProcessExecuter::ArgumentError' do
+#         expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
+#       end
+#     end
+#   end
 
-    context 'when given options is a Hash' do
-      let(:given_options) { { logger: Logger.new(nil) } }
-      it 'should return a RunOptions object with the same options' do
-        expect(subject).to be_a(ProcessExecuter::Options::RunOptions)
-        expect(subject.to_h).to include(given_options)
-      end
-    end
+#   describe '.run_options' do
+#     subject { ProcessExecuter.run_options(given_options) }
 
-    context 'when given options is a ProcessExecuter::Options::RunOptions' do
-      let(:given_options) { ProcessExecuter::Options::RunOptions.new(logger: Logger.new(nil)) }
-      it 'should return the given object' do
-        expect(subject.object_id).to eq(given_options.object_id)
-      end
-    end
+#     context 'when given options is a Hash' do
+#       let(:given_options) { { logger: Logger.new(nil) } }
+#       it 'should return a RunOptions object with the same options' do
+#         expect(subject).to be_a(ProcessExecuter::Options::RunOptions)
+#         expect(subject.to_h).to include(given_options)
+#       end
+#     end
 
-    context 'when given options any other kind of option' do
-      let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
-      end
-    end
-  end
-end
+#     context 'when given options is a ProcessExecuter::Options::RunOptions' do
+#       let(:given_options) { ProcessExecuter::Options::RunOptions.new(logger: Logger.new(nil)) }
+#       it 'should return the given object' do
+#         expect(subject.object_id).to eq(given_options.object_id)
+#       end
+#     end
+
+#     context 'when given options any other kind of option' do
+#       let(:given_options) { Object.new }
+#       it 'should raise an ProcessExecuter::ArgumentError' do
+#         expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
+#       end
+#     end
+#   end
+# end


### PR DESCRIPTION
Summary of changes:

1. ProcessExecuter.run will no longer capture stdout and stderr.

To do this meant adding very hacky capture of any destination whether you
wanted it or not which caused overhead for no good reason.

Later ProcessExecuter.run_with_capture will be added which will capture
stdout and stderr specifically without doing it for every redirection
destination.

2. Removed #stdout and #stderr from Result

Since capture is no longer needed in ProcessExecuter.run, these methods
were removed from Result.

Later, when ProcessExecuter.run_with_capture is added, ResultWithCapture
which will add accessors for stdout and stderr captured from the command.
ResultWithCapture will derive from Result.

3. ProcessExecuter.spawn_and_wait was renamed to spawn_with_timeout

This was done to better describe what this method added over basic
Process.spawn.

4. ProcessExecuter.spawn_with_timeout can accept an options object

Before there were two different methods:
(1) spawn_with_timeout(*command, **options_hash)
(2) spawn_with_timeout_with_options(command, options)

Method (1) took an splatted command array and splatted options HASH.
Method (2) took a command array and an options OBJECT.

These have been fused into one method where the options object can be
the last entry in the command array.

It can be called like this:
spawn_with_timeout(*command, options_object)
or
spawn_with_timeout(*command, **options_hash)

This was done so that the public interface was easier to use. The
"_with_options" variant was confusing because `command` was not
splatted.

5. ProcessExecuter.run can accept an options object

The same change that was applied to ProcessExecuter.spawn_with_timeout
in the previous point was applied to ProcessExecuter.run.

6. Raise ProcessExecuter::ArgumentError instead of ArgumentError

This was done so that all errors raised by this gem derive from
ProcessExecuter::Error.