### PR TITLE
Raise ProcessExecuter::ArgumentError instead of ::ArgumentError

### DIFF
--- a/lib/process_executer/errors.rb
+++ b/lib/process_executer/errors.rb
@@ -13,6 +13,7 @@ module ProcessExecuter
   # ```text
   # ::StandardError
   #   └─> Error
+  #       ├─> ArgumentError
   #       ├─> CommandError
   #       │   ├─> FailedError
   #       │   └─> SignaledError
@@ -24,6 +25,7 @@ module ProcessExecuter
   # | Error Class | Description |
   # | --- | --- |
   # | `Error` | This catch-all error serves as the base class for other custom errors. |
+  # | `ArgumentError` | Raised when an invalid argument is passed to a method. |
   # | `CommandError` | A subclass of this error is raised when there is a problem executing a command. |
   # | `FailedError` | Raised when the command exits with a non-zero status code. |
   # | `SignaledError` | Raised when the command is terminated as a result of receiving a signal. This could happen if the process is forcibly terminated or if there is a serious system error. |
@@ -51,6 +53,18 @@ module ProcessExecuter
   # @api public
   #
   class Error < ::StandardError; end
+
+  # Raised when an invalid argument is passed to a method
+  #
+  # @example
+  #   begin
+  #     # Command should not be an array
+  #     ProcessExecuter.run(nil, timeout_after: -1)
+  #   rescue ProcessExecuter::ArgumentError => e
+  #     e.message #=> "Command elements must be a String"
+  #   end
+  #
+  class ArgumentError < ProcessExecuter::Error; end
 
   # Raised when a command fails or exits because of an uncaught signal
   #

--- a/spec/process_executer/monitored_pipe_spec.rb
+++ b/spec/process_executer/monitored_pipe_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
   context 'when used to wrap an output destination for Process.spawn' do
     context 'when the output destination is nil' do
       let(:destination) { nil }
-      it 'should raise an ArgumentError' do
-        expect { ProcessExecuter::MonitoredPipe.new(nil) }.to raise_error(ArgumentError, 'wrong exec redirect action')
+      it 'should raise an ProcessExecuter::ArgumentError' do
+        expect { ProcessExecuter::MonitoredPipe.new(nil) }.to(
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
+        )
       end
     end
 
@@ -160,9 +162,9 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
 
     context 'when the output destination is an array in the form [filepath]' do
       # [filepath] only works for stdin
-      it 'should raise an ArgumentError' do
+      it 'should raise an ProcessExecuter::ArgumentError' do
         expect { ProcessExecuter::MonitoredPipe.new(['filepath']) }.to(
-          raise_error(ArgumentError, 'wrong exec redirect action')
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
         )
       end
     end
@@ -177,7 +179,7 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
           ProcessExecuter::MonitoredPipe.assert_no_open_instances
         end
 
-        it 'should raise an ArgumentError' do
+        it 'the exception methods should note that an IOError was raised' do
           command = ruby_command(<<~COMMAND)
             puts 'stdout output'
           COMMAND
@@ -419,18 +421,18 @@ RSpec.describe ProcessExecuter::MonitoredPipe do
 
     context 'when the output destination is an array in the form [:child, fd]' do
       # redirect the source to the destination fd in the child process
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { ProcessExecuter::MonitoredPipe.new([:child, 1]) }.to(
-          raise_error(ArgumentError, 'Destination [:child, 1] is not compatible with MonitoredPipe')
+          raise_error(ProcessExecuter::ArgumentError, 'Destination [:child, 1] is not compatible with MonitoredPipe')
         )
       end
     end
 
     context 'when the output destination is :close' do
       # close the fd in the child process
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { ProcessExecuter::MonitoredPipe.new(:close) }.to(
-          raise_error(ArgumentError, 'wrong exec redirect action')
+          raise_error(ProcessExecuter::ArgumentError, 'wrong exec redirect action')
         )
       end
     end

--- a/spec/process_executer/options/base_spec.rb
+++ b/spec/process_executer/options/base_spec.rb
@@ -17,15 +17,15 @@ RSpec.describe ProcessExecuter::Options::Base do
 
     context 'when a single unknown option is given' do
       let(:options_hash) { { unknown: true } }
-      it 'should raise an error' do
-        expect { options }.to raise_error(ArgumentError, 'Unknown option: unknown')
+      it 'should raise a ProcessExecuter::ArgumentError' do
+        expect { options }.to raise_error(ProcessExecuter::ArgumentError, 'Unknown option: unknown')
       end
     end
 
     context 'when multiple unknown options are given' do
       let(:options_hash) { { unknown1: true, unknown2: false } }
-      it 'should raise an error' do
-        expect { options }.to raise_error(ArgumentError, 'Unknown options: unknown1, unknown2')
+      it 'should raise a ProcessExecuter::ArugmentError' do
+        expect { options }.to raise_error(ProcessExecuter::ArgumentError, 'Unknown options: unknown1, unknown2')
       end
     end
   end
@@ -218,7 +218,7 @@ RSpec.describe ProcessExecuter::Options::Base do
           lambda {
             unless an_option.is_a?(String)
               raise(
-                ArgumentError,
+                ProcessExecuter::ArgumentError,
                 "an_option must be a string but was #{an_option.inspect}"
               )
             end
@@ -236,8 +236,10 @@ RSpec.describe ProcessExecuter::Options::Base do
         context 'when the option is set to an invalid value' do
           let(:options_hash) { { an_option: 123 } }
 
-          it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, 'an_option must be a string but was 123')
+          it 'should raise an ProcessExecuter::ArgumentError' do
+            expect { subject }.to(
+              raise_error(ProcessExecuter::ArgumentError, 'an_option must be a string but was 123')
+            )
           end
         end
       end
@@ -325,24 +327,26 @@ RSpec.describe ProcessExecuter::Options::Base do
         context 'when given an invalid value for option1' do
           let(:options_hash) { { option1: 123, option2: 2 } }
 
-          it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, 'option1 must be a String')
+          it 'should raise an ProcessExecuter::ArgumentError' do
+            expect { subject }.to raise_error(ProcessExecuter::ArgumentError, 'option1 must be a String')
           end
         end
 
         context 'when given an invalid value for option2' do
           let(:options_hash) { { option1: 'value1', option2: 'invalid' } }
 
-          it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, 'option2 must be an Integer')
+          it 'should raise an ProcessExecuter::ArgumentError' do
+            expect { subject }.to raise_error(ProcessExecuter::ArgumentError, 'option2 must be an Integer')
           end
         end
 
         context 'when given an invalid value for both option1 and option2' do
           let(:options_hash) { { option1: 123, option2: 'invalid' } }
 
-          it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError, "option1 must be a String\noption2 must be an Integer")
+          it 'should raise an ProcessExecuter::ArgumentError' do
+            expect do
+              subject
+            end.to raise_error(ProcessExecuter::ArgumentError, "option1 must be a String\noption2 must be an Integer")
           end
         end
       end

--- a/spec/process_executer/options/run_options_spec.rb
+++ b/spec/process_executer/options/run_options_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
     context 'when giving -1 for timeout_after' do
       let(:options_hash) { { timeout_after: -1 } }
 
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was -1'
           )
         )
@@ -59,10 +59,10 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
     context 'when given an invalid logger value' do
       let(:options_hash) { { logger: 'invalid' } }
 
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'logger must respond to #info and #debug but was "invalid"'
           )
         )
@@ -80,10 +80,10 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
     context 'when given an invalid raise_errors value' do
       let(:options_hash) { { raise_errors: nil } }
 
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'raise_errors must be true or false but was nil'
           )
         )
@@ -101,10 +101,10 @@ RSpec.describe ProcessExecuter::Options::RunOptions do
     context 'when given timeout_after "invalid"' do
       let(:options_hash) { { timeout_after: 'invalid' } }
 
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was "invalid"'
           )
         )

--- a/spec/process_executer/options/spawn_and_wait_options_spec.rb
+++ b/spec/process_executer/options/spawn_and_wait_options_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe ProcessExecuter::Options::SpawnAndWaitOptions do
     context 'when given timeout_after "invalid"' do
       let(:options_hash) { { timeout_after: 'invalid' } }
 
-      it 'should raise an error' do
+      it 'should raise a ProcessExecuter::ArgumentError' do
         expect { subject }.to(
           raise_error(
-            ArgumentError,
+            ProcessExecuter::ArgumentError,
             'timeout_after must be nil or a non-negative real number but was "invalid"'
           )
         )

--- a/spec/process_executer/options/spawn_options_spec.rb
+++ b/spec/process_executer/options/spawn_options_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe ProcessExecuter::Options::SpawnOptions do
     end
 
     context 'when an unknown option is given' do
-      it 'should raise an ArgumentError' do
-        expect { described_class.new(unknown: true) }.to raise_error(ArgumentError, 'Unknown option: unknown')
+      it 'should raise a ProcessExecuter::ArgumentError' do
+        expect { described_class.new(unknown: true) }.to(
+          raise_error(ProcessExecuter::ArgumentError, 'Unknown option: unknown')
+        )
       end
     end
   end

--- a/spec/process_executer/options_conversions_spec.rb
+++ b/spec/process_executer/options_conversions_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ProcessExecuter do
 
     context 'when given options any other kind of option' do
       let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
+      it 'should raise an ProcessExecuter::ArgumentError' do
+        expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
       end
     end
   end
@@ -47,8 +47,8 @@ RSpec.describe ProcessExecuter do
 
     context 'when given options any other kind of option' do
       let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
+      it 'should raise an ProcessExecuter::ArgumentError' do
+        expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
       end
     end
   end
@@ -73,8 +73,8 @@ RSpec.describe ProcessExecuter do
 
     context 'when given options any other kind of option' do
       let(:given_options) { Object.new }
-      it 'should raise an ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
+      it 'should raise a ProcessExecuter::ArgumentError' do
+        expect { subject }.to raise_error(ProcessExecuter::ArgumentError)
       end
     end
   end

--- a/spec/process_executer_spawn_and_wait_spec.rb
+++ b/spec/process_executer_spawn_and_wait_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe ProcessExecuter do
       context 'when :timeout_after is a String' do
         let(:command) { %w[echo hello] }
         let(:options) { { timeout_after: 'a string' } }
-        it 'should raise an ArgumentError' do
-          expect { subject }.to raise_error(ArgumentError, /timeout_after must be/)
+        it 'should raise an ProcessExecuter::ArgumentError' do
+          expect { subject }.to raise_error(ProcessExecuter::ArgumentError, /timeout_after must be/)
         end
       end
 
       context 'when :timeout_after is a Complex' do
         let(:command) { %w[echo hello] }
         let(:options) { { timeout_after: Complex(3, 4) } }
-        it 'should raise an ArgumentError' do
-          expect { subject }.to raise_error(ArgumentError, /timeout_after must be/)
+        it 'should raise an ProcessExecuter::ArgumentError' do
+          expect { subject }.to raise_error(ProcessExecuter::ArgumentError, /timeout_after must be/)
         end
       end
 


### PR DESCRIPTION
This was done so that all errors raised by this gem that user might be able to handle should derive from ProcessExecuter::Error.

BREAKING CHANGE: In places where users of this gem rescued ::ArgumentError, they # will have to change the rescued class to ProcessExecuter::ArgumentError.