### PR TITLE
Remove unneeded :nocov: blocks

### DIFF
--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -228,12 +228,10 @@ module ProcessExecuter
 
         return if unknown_options.empty?
 
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
         raise(
           ArgumentError,
           "Unknown option#{unknown_options.count > 1 ? 's' : ''}: #{unknown_options.join(', ')}"
         )
-        # :nocov:
       end
     end
   end

--- a/lib/process_executer/options/run_options.rb
+++ b/lib/process_executer/options/run_options.rb
@@ -12,8 +12,6 @@ module ProcessExecuter
     class RunOptions < SpawnAndWaitOptions
       private
 
-      # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
-
       # The options allowed for objects of this class
       # @return [Array<OptionDefinition>]
       # @api private
@@ -24,7 +22,6 @@ module ProcessExecuter
           OptionDefinition.new(:logger, default: Logger.new(nil), validator: method(:validate_logger))
         ].freeze
       end
-      # :nocov:
 
       # Validate the raise_errors option value
       # @return [String, nil] the error message if the value is not valid

--- a/lib/process_executer/options/spawn_and_wait_options.rb
+++ b/lib/process_executer/options/spawn_and_wait_options.rb
@@ -16,12 +16,10 @@ module ProcessExecuter
       # @return [Array<OptionDefinition>]
       # @api private
       def define_options
-        # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
         [
           *super,
           OptionDefinition.new(:timeout_after, default: nil, validator: method(:validate_timeout_after))
         ].freeze
-        # :nocov:
       end
 
       # Raise an error unless timeout_after is nil or a non-negative real number

--- a/lib/process_executer/options/spawn_options.rb
+++ b/lib/process_executer/options/spawn_options.rb
@@ -14,7 +14,6 @@ module ProcessExecuter
     # @api public
     #
     class SpawnOptions < Base
-      # :nocov: SimpleCov on JRuby reports hashes declared on multiple lines as not covered
       SPAWN_OPTIONS = [
         OptionDefinition.new(:unsetenv_others, default: :not_set),
         OptionDefinition.new(:pgroup, default: :not_set),
@@ -24,7 +23,6 @@ module ProcessExecuter
         OptionDefinition.new(:close_others, default: :not_set),
         OptionDefinition.new(:chdir, default: :not_set)
       ].freeze
-      # :nocov:
 
       # Returns the options to be passed to Process.spawn
       #


### PR DESCRIPTION
Since we are only running coverage now on MRI Ruby, there were some :nocov: blocks that were missed that were needed for JRuby coverage.