### PR TITLE
Rename ProcessExecuter.spawn_and_wait to spawn_with_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,29 +28,29 @@ then click the "Documentation" link.
 
 ## Table of Contents
 
-* [Requirements](#requirements)
-* [Table of Contents](#table-of-contents)
-* [Usage](#usage)
-    * [ProcessExecuter::MonitoredPipe](#processexecutermonitoredpipe)
-    * [ProcessExecuter::Result](#processexecuterresult)
-    * [ProcessExecuter.spawn\_and\_wait](#processexecuterspawn_and_wait)
-    * [ProcessExecuter.run](#processexecuterrun)
-* [Breaking Changes](#breaking-changes)
-    * [2.x](#2x)
-        * [`ProcessExecuter.spawn`](#processexecuterspawn)
-        * [`ProcessExecuter.run`](#processexecuterrun-1)
-        * [`ProcessExecuter::Result`](#processexecuterresult-1)
-        * [Other](#other)
-    * [3.x](#3x)
-        * [`ProcessExecuter.run`](#processexecuterrun-2)
-* [Installation](#installation)
-* [Contributing](#contributing)
-    * [Reporting Issues](#reporting-issues)
-    * [Developing](#developing)
-    * [Commit message guidelines](#commit-message-guidelines)
-    * [Pull request guidelines](#pull-request-guidelines)
-    * [Releasing](#releasing)
-* [License](#license)
+- [Requirements](#requirements)
+- [Table of Contents](#table-of-contents)
+- [Usage](#usage)
+  - [ProcessExecuter::MonitoredPipe](#processexecutermonitoredpipe)
+  - [ProcessExecuter::Result](#processexecuterresult)
+  - [ProcessExecuter.spawn\_with\_timeout](#processexecuterspawn_with_timeout)
+  - [ProcessExecuter.run](#processexecuterrun)
+- [Breaking Changes](#breaking-changes)
+  - [2.x](#2x)
+    - [`ProcessExecuter.spawn`](#processexecuterspawn)
+    - [`ProcessExecuter.run`](#processexecuterrun-1)
+    - [`ProcessExecuter::Result`](#processexecuterresult-1)
+    - [Other](#other)
+  - [3.x](#3x)
+    - [`ProcessExecuter.run`](#processexecuterrun-2)
+- [Installation](#installation)
+- [Contributing](#contributing)
+  - [Reporting Issues](#reporting-issues)
+  - [Developing](#developing)
+  - [Commit message guidelines](#commit-message-guidelines)
+  - [Pull request guidelines](#pull-request-guidelines)
+  - [Releasing](#releasing)
+- [License](#license)
 
 ## Usage
 
@@ -70,9 +70,9 @@ Classes:
 
 Methods:
 
-* `ProcessExecuter.spawn_and_wait`: execute a subprocess and wait for it to exit with
+* `ProcessExecuter.spawn_with_timeout`: execute a subprocess and wait for it to exit with
   an optional timeout. Supports the same interface and features as `Process.spawn`.
-* `ProcessExecuter.run`: builds upon `.spawn_and_wait` adding (1) automatically
+* `ProcessExecuter.run`: builds upon `.spawn_with_timeout` adding (1) automatically
   wrapping stdout and stderr destinations (if given) in a `MonitoredPipe` and (2)
   raises errors for any problem executing the subprocess (can be turned off).
 
@@ -125,14 +125,14 @@ File.read('process.out') #=> "Hello World\n"
 
 ### ProcessExecuter::Result
 
-An instance of this class is returned from both `.spawn_and_wait` and `.run`.
+An instance of this class is returned from both `.spawn_with_timeout` and `.run`.
 
 This class is an extension of
 [Process::Status](https://docs.ruby-lang.org/en/3.3/Process/Status.html) so it
 supports the same interface with the following additions:
 
-* `#command`: the command given to `.spawn_and_wait` or `.run`
-* `#options`: the options given to `.spawn_and_wait` or `.run` (possibly with some
+* `#command`: the command given to `.spawn_with_timeout` or `.run`
+* `#options`: the options given to `.spawn_with_timeout` or `.run` (possibly with some
   changes)
 * `#timed_out?`: true if the process was killed after running for `:timeout_after`
   seconds
@@ -142,9 +142,9 @@ supports the same interface with the following additions:
 * `#stderr`: the captured stderr from the subprocess (if the stderr destination was
   wrapped by a `MonitoredPipe`)
 
-### ProcessExecuter.spawn_and_wait
+### ProcessExecuter.spawn_with_timeout
 
-`ProcessExecuter.spawn_and_wait` has the same interface and features as
+`ProcessExecuter.spawn_with_timeout` has the same interface and features as
 [Process.spawn](https://docs.ruby-lang.org/en/3.3/Process.html#method-c-spawn)
 with the following differences:
 
@@ -157,7 +157,7 @@ If the command does not terminate before the number of seconds specified by
 returned Result object's `timed_out?` attribute will return `true`. For example:
 
 ```ruby
-result = ProcessExecuter.spawn_and_wait('sleep 10', timeout_after: 0.01)
+result = ProcessExecuter.spawn_with_timeout('sleep 10', timeout_after: 0.01)
 result.signaled? #=> true
 result.termsig #=> 9
 result.timed_out? #=> true
@@ -169,7 +169,7 @@ subprocess output from its `#stdout` and `#stderr` methods.
 
 ### ProcessExecuter.run
 
-`ProcessExecuter.run` builds upon `ProcessExecuter.spawn_and_wait` adding the
+`ProcessExecuter.run` builds upon `ProcessExecuter.spawn_with_timeout` adding the
 following features:
 
 * It automatically wraps any given stdout and stderr destination with a
@@ -193,7 +193,7 @@ This major release focused on changes to the interface to make it more understan
 
 #### `ProcessExecuter.spawn`
 
-* This method was renamed to `ProcessExecuter.spawn_and_wait`
+* This method was renamed to `ProcessExecuter.spawn_with_timeout`
 * The `:timeout` option was renamed to `:timeout_after`
 
 #### `ProcessExecuter.run`

--- a/lib/process_executer.rb
+++ b/lib/process_executer.rb
@@ -17,10 +17,10 @@ require 'process_executer/runner'
 #
 # Methods:
 #
+# * {spawn_with_timeout}: a thin wrapper around `Process.spawn` that blocks until the
+#   command finishes
 # * {run}: Executes a command and returns the result which includes the process
 #   status and output
-# * {spawn_and_wait}: a thin wrapper around `Process.spawn` that blocks until the
-#   command finishes
 #
 # Features:
 #
@@ -42,13 +42,13 @@ module ProcessExecuter
   # sent the SIGKILL signal if it does not terminate within the specified timeout.
   #
   # @example
-  #   result = ProcessExecuter.spawn_and_wait('echo hello')
+  #   result = ProcessExecuter.spawn_with_timeout('echo hello')
   #   result.exited? # => true
   #   result.success? # => true
   #   result.timed_out? # => false
   #
   # @example with a timeout
-  #   result = ProcessExecuter.spawn_and_wait('sleep 10', timeout_after: 0.01)
+  #   result = ProcessExecuter.spawn_with_timeout('sleep 10', timeout_after: 0.01)
   #   result.exited? # => false
   #   result.success? # => nil
   #   result.signaled? # => true
@@ -58,7 +58,7 @@ module ProcessExecuter
   # @example capturing stdout to a string
   #   stdout_buffer = StringIO.new
   #   stdout_pipe = ProcessExecuter::MonitoredPipe.new(stdout_buffer)
-  #   result = ProcessExecuter.spawn_and_wait('echo hello', out: stdout_pipe)
+  #   result = ProcessExecuter.spawn_with_timeout('echo hello', out: stdout_pipe)
   #   stdout_buffer.string # => "hello\n"
   #
   # @see https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-spawn Kernel.spawn
@@ -72,21 +72,21 @@ module ProcessExecuter
   #
   # @return [ProcessExecuter::Result] The result of the completed subprocess
   #
-  def self.spawn_and_wait(*command, **options_hash)
-    options = ProcessExecuter.spawn_and_wait_options(options_hash)
-    spawn_and_wait_with_options(command, options)
+  def self.spawn_with_timeout(*command, **options_hash)
+    options = ProcessExecuter.spawn_with_timeout_options(options_hash)
+    spawn_with_timeout_with_options(command, options)
   end
 
   # Run a command in a subprocess, wait for it to finish, then return the result
   #
-  # @see ProcessExecuter.spawn_and_wait for full documentation
+  # @see ProcessExecuter.spawn_with_timeout for full documentation
   #
   # @param command [Array<String>] The command to run
-  # @param options [ProcessExecuter::Options::SpawnAndWaitOptions] The options to use when running the command
+  # @param options [ProcessExecuter::Options::SpawnWithTimeoutOptions] The options to use when running the command
   #
   # @return [ProcessExecuter::Result] The result of the completed subprocess
   # @api private
-  def self.spawn_and_wait_with_options(command, options)
+  def self.spawn_with_timeout_with_options(command, options)
     begin
       pid = Process.spawn(*command, **options.spawn_options)
     rescue StandardError => e
@@ -383,31 +383,31 @@ module ProcessExecuter
     end
   end
 
-  # Convert a hash to a SpawnAndWaitOptions object
+  # Convert a hash to a SpawnWithTimeoutOptions object
   #
   # @example
   #   options_hash = { out: $stdout }
-  #   options = ProcessExecuter.spawn_and_wait_options(options_hash) # =>
-  #     #<ProcessExecuter::Options::SpawnAndWaitOptions:0x00007f8f9b0b3d20 out: $stdout>
-  #   ProcessExecuter.spawn_and_wait_options(options) # =>
-  #     #<ProcessExecuter::Options::SpawnAndWaitOptions:0x00007f8f9b0b3d20 out: $stdout>
+  #   options = ProcessExecuter.spawn_with_timeout_options(options_hash) # =>
+  #     #<ProcessExecuter::Options::SpawnWithTimeoutOptions:0x00007f8f9b0b3d20 out: $stdout>
+  #   ProcessExecuter.spawn_with_timeout_options(options) # =>
+  #     #<ProcessExecuter::Options::SpawnWithTimeoutOptions:0x00007f8f9b0b3d20 out: $stdout>
   #
-  # @param obj [Hash, SpawnAndWaitOptions] the object to be converted
+  # @param obj [Hash, SpawnWithTimeoutOptions] the object to be converted
   #
-  # @return [SpawnAndWaitOptions]
+  # @return [SpawnWithTimeoutOptions]
   #
   # @raise [ArgumentError] if obj is not a Hash or SpawnOptions
   #
   # @api public
   #
-  def self.spawn_and_wait_options(obj)
+  def self.spawn_with_timeout_options(obj)
     case obj
-    when ProcessExecuter::Options::SpawnAndWaitOptions
+    when ProcessExecuter::Options::SpawnWithTimeoutOptions
       obj
     when Hash
-      ProcessExecuter::Options::SpawnAndWaitOptions.new(**obj)
+      ProcessExecuter::Options::SpawnWithTimeoutOptions.new(**obj)
     else
-      raise ArgumentError, "Expected a Hash or ProcessExecuter::Options::SpawnAndWaitOptions but got a #{obj.class}"
+      raise ArgumentError, "Expected a Hash or ProcessExecuter::Options::SpawnWithTimeoutOptions but got a #{obj.class}"
     end
   end
 

--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -2,7 +2,7 @@
 
 require_relative 'options/base'
 require_relative 'options/spawn_options'
-require_relative 'options/spawn_and_wait_options'
+require_relative 'options/spawn_with_timeout_options'
 require_relative 'options/run_options'
 require_relative 'options/option_definition'
 

--- a/lib/process_executer/options/run_options.rb
+++ b/lib/process_executer/options/run_options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'spawn_and_wait_options'
+require_relative 'spawn_with_timeout_options'
 require_relative 'option_definition'
 
 module ProcessExecuter
@@ -9,7 +9,7 @@ module ProcessExecuter
     #
     # @api public
     #
-    class RunOptions < SpawnAndWaitOptions
+    class RunOptions < SpawnWithTimeoutOptions
       private
 
       # The options allowed for objects of this class

--- a/lib/process_executer/options/spawn_with_timeout_options.rb
+++ b/lib/process_executer/options/spawn_with_timeout_options.rb
@@ -5,11 +5,11 @@ require_relative 'option_definition'
 
 module ProcessExecuter
   module Options
-    # Define options for the `ProcessExecuter.spawn_and_wait`
+    # Define options for the `ProcessExecuter.spawn_with_timeout`
     #
     # @api public
     #
-    class SpawnAndWaitOptions < SpawnOptions
+    class SpawnWithTimeoutOptions < SpawnOptions
       private
 
       # The options allowed for objects of this class

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -50,7 +50,7 @@ module ProcessExecuter
     #
     def spawn(command, options)
       opened_pipes = wrap_stdout_stderr(options)
-      ProcessExecuter.spawn_and_wait_with_options(command, options)
+      ProcessExecuter.spawn_with_timeout_with_options(command, options)
     ensure
       opened_pipes.each_value(&:close)
       opened_pipes.each { |option_key, pipe| raise_pipe_error(command, option_key, pipe) }

--- a/spec/process_executer/options/spawn_with_timeout_options_spec.rb
+++ b/spec/process_executer/options/spawn_with_timeout_options_spec.rb
@@ -2,7 +2,7 @@
 
 require 'stringio'
 
-RSpec.describe ProcessExecuter::Options::SpawnAndWaitOptions do
+RSpec.describe ProcessExecuter::Options::SpawnWithTimeoutOptions do
   let(:options) { described_class.new(**options_hash) }
   let(:options_hash) { {} }
 

--- a/spec/process_executer/options_conversions_spec.rb
+++ b/spec/process_executer/options_conversions_spec.rb
@@ -27,19 +27,19 @@ RSpec.describe ProcessExecuter do
     end
   end
 
-  describe '.spawn_and_wait_options' do
-    subject { ProcessExecuter.spawn_and_wait_options(given_options) }
+  describe '.spawn_with_timeout_options' do
+    subject { ProcessExecuter.spawn_with_timeout_options(given_options) }
 
     context 'when given options is a Hash' do
       let(:given_options) { { timeout_after: 10 } }
-      it 'should return a SpawnAndWaitOptions object with the same options' do
-        expect(subject).to be_a(ProcessExecuter::Options::SpawnAndWaitOptions)
+      it 'should return a SpawnWithTimeoutOptions object with the same options' do
+        expect(subject).to be_a(ProcessExecuter::Options::SpawnWithTimeoutOptions)
         expect(subject.to_h).to include(given_options)
       end
     end
 
-    context 'when given options is a ProcessExecuter::Options::SpawnAndWaitOptions' do
-      let(:given_options) { ProcessExecuter::Options::SpawnAndWaitOptions.new(timeout_after: 10) }
+    context 'when given options is a ProcessExecuter::Options::SpawnWithTimeoutOptions' do
+      let(:given_options) { ProcessExecuter::Options::SpawnWithTimeoutOptions.new(timeout_after: 10) }
       it 'should return the given object' do
         expect(subject.object_id).to eq(given_options.object_id)
       end

--- a/spec/process_executer_spawn_with_timeout_spec.rb
+++ b/spec/process_executer_spawn_with_timeout_spec.rb
@@ -5,8 +5,8 @@ require 'logger'
 require 'tmpdir'
 
 RSpec.describe ProcessExecuter do
-  describe '.spawn_and_wait' do
-    subject { ProcessExecuter.spawn_and_wait(*command, **options) }
+  describe '.spawn_with_timeout' do
+    subject { ProcessExecuter.spawn_with_timeout(*command, **options) }
 
     context 'when an invalid command is given' do
       let(:command) { 'invalid_command' }


### PR DESCRIPTION
This change is being made to feature the timeout functionality of this method.

BREAKING CHANGE: Users who use ProcessExecuter.spawn_and_wait will need to update their calls to spawn_with_timeout. In addition, the following items will need to be updated if used by the user of this gem:

* ProcessExecuter.spawn_and_wait_with_options
* ProcessExecuter::SpawnAndWaitOptions