### PR TITLE
Remove Result#stdout and Result#stderr

### DIFF
--- a/lib/process_executer/destination_base.rb
+++ b/lib/process_executer/destination_base.rb
@@ -22,27 +22,13 @@ module ProcessExecuter
     # @return [Object] the destination object
     attr_reader :destination
 
-    # The data written to the destination
-    #
-    # @return [Array<String>] the data written to the destination
-    attr_reader :data_written
-
-    # The data written to the destination as a single string
-    # @return [String]
-    def string
-      data_written.join
-    end
-
     # Writes data to the destination
     #
     # This is an abstract method that must be implemented by subclasses.
     #
     # @param data [String] the data to write
     # @return [void]
-    # @raise [NotImplementedError] if the subclass doesn't implement this method
-    def write(data)
-      @data_written << data
-    end
+    def write(data); end
 
     # Closes the destination if necessary
     #

--- a/lib/process_executer/errors.rb
+++ b/lib/process_executer/errors.rb
@@ -104,7 +104,7 @@ module ProcessExecuter
     # @return [String]
     #
     def error_message
-      "#{result.command}, status: #{result}, stderr: #{result.stderr.inspect}"
+      "#{result.command}, status: #{result}"
     end
 
     # @attribute [r] result

--- a/lib/process_executer/options/spawn_options.rb
+++ b/lib/process_executer/options/spawn_options.rb
@@ -66,39 +66,11 @@ module ProcessExecuter
       # @api private
       def stdout_redirection?(option_key) = std_redirection?(option_key, :out, 1)
 
-      # Determine the option key that indicates a redirection option for stdout
-      # @return [Symbol, Integer, IO, Array, nil] nil if not found
-      # @api private
-      def stdout_redirection_key
-        options.keys.find { |option_key| option_key if stdout_redirection?(option_key) }
-      end
-
-      # Determine the value of the redirection option for stdout
-      # @return [Object]
-      # @api private
-      def stdout_redirection_value
-        options[stdout_redirection_key]
-      end
-
       # Determine if the given option key indicates a redirection option for stderr
       # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
       # @return [Boolean]
       # @api private
       def stderr_redirection?(option_key) = std_redirection?(option_key, :err, 2)
-
-      # Determine the option key that indicates a redirection option for stderr
-      # @return [Symbol, Integer, IO, Array, nil] nil if not found
-      # @api private
-      def stderr_redirection_key
-        options.keys.find { |option_key| option_key if stderr_redirection?(option_key) }
-      end
-
-      # Determine the value of the redirection option for stderr
-      # @return [Object]
-      # @api private
-      def stderr_redirection_value
-        options[stderr_redirection_key]
-      end
 
       private
 

--- a/lib/process_executer/result.rb
+++ b/lib/process_executer/result.rb
@@ -8,8 +8,6 @@ module ProcessExecuter
   # * `command`: the command that was used to spawn the process
   # * `options`: the options that were used to spawn the process
   # * `elapsed_time`: the secs the command ran
-  # * `stdout`: the captured stdout output
-  # * `stderr`: the captured stderr output
   # * `timed_out?`: true if the process timed out
   #
   # @api public
@@ -105,46 +103,6 @@ module ProcessExecuter
     # @return [String]
     def to_s
       "#{super}#{timed_out? ? " timed out after #{options.timeout_after}s" : ''}"
-    end
-
-    # Return the captured stdout output
-    #
-    # This output is only returned if the `:out` option value is a
-    # `ProcessExecuter::MonitoredPipe`.
-    #
-    # @example
-    #   # Note that `ProcessExecuter.run` will wrap the given out: object in a
-    #   # ProcessExecuter::MonitoredPipe
-    #   result = ProcessExecuter.run('echo hello': out: StringIO.new)
-    #   result.stdout #=> "hello\n"
-    #
-    # @return [String, nil]
-    #
-    def stdout
-      pipe = options.stdout_redirection_value
-      return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
-
-      pipe.destination.string
-    end
-
-    # Return the captured stderr output
-    #
-    # This output is only returned if the `:err` option value is a
-    # `ProcessExecuter::MonitoredPipe`.
-    #
-    # @example
-    #   # Note that `ProcessExecuter.run` will wrap the given err: object in a
-    #   # ProcessExecuter::MonitoredPipe
-    #   result = ProcessExecuter.run('echo ERROR 1>&2', err: StringIO.new)
-    #   resuilt.stderr #=> "ERROR\n"
-    #
-    # @return [String, nil]
-    #
-    def stderr
-      pipe = options.stderr_redirection_value
-      return nil unless pipe.is_a?(ProcessExecuter::MonitoredPipe)
-
-      pipe.destination.string
     end
   end
 end


### PR DESCRIPTION
Do not automatically capture stdout and stderr and return it in the Result object.

The way it was implemented, stdout and stderr were only captured if wrapped in a
MonitoredPipe. It also meant that every MonitoredPipe output destination was captured
even if it was not from stdout or stderr.

The new method will be added to the API `ProcessExecuter.run_with_capture` that
captures ONLY stdout and stderr and returns a `ResultWithCapture` which derives from
`Result` and has `#stdout` and `#stderr` methods.

BREAKING CHANGE: Users depending on `Result#stdout` or `Result#stderr` will either
have to capture this output manually themselves or change from `spawn_and_wait`/`run`
to `run_with_capture`.