### PR TITLE
Add `ProcessExecuter.run_with_capture`

### DIFF
--- a/lib/process_executer/options.rb
+++ b/lib/process_executer/options.rb
@@ -4,6 +4,7 @@ require_relative 'options/base'
 require_relative 'options/spawn_options'
 require_relative 'options/spawn_with_timeout_options'
 require_relative 'options/run_options'
+require_relative 'options/run_with_capture_options'
 require_relative 'options/option_definition'
 
 module ProcessExecuter

--- a/lib/process_executer/options/base.rb
+++ b/lib/process_executer/options/base.rb
@@ -133,7 +133,8 @@ module ProcessExecuter
       #   options.option1 # => 'value1'
       #   options.option2 # => 'value2'
       #
-      # @options_hash [Hash] the options to merge into the current options
+      # @param options_hash [Hash] the options to merge into the current options
+      #
       # @return [self.class]
       #
       def with(**options_hash)

--- a/lib/process_executer/options/run_with_capture_options.rb
+++ b/lib/process_executer/options/run_with_capture_options.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'option_definition'
+require_relative 'run_options'
+
+module ProcessExecuter
+  module Options
+    # Define options for the `ProcessExecuter.run`
+    #
+    # @api public
+    #
+    class RunWithCaptureOptions < RunOptions
+      private
+
+      # The options allowed for objects of this class
+      # @return [Array<OptionDefinition>]
+      # @api private
+      def define_options
+        [
+          *super,
+          OptionDefinition.new(:merge_output, default: false, validator: method(:validate_merge_output))
+        ].freeze
+      end
+
+      # Validate the merge_output option value
+      # @return [String, nil] the error message if the value is not valid
+      # @api private
+      def validate_merge_output
+        if [true, false].include?(merge_output)
+          if merge_output == true && stderr_redirection_key
+            errors << 'Can not give merge_output: true AND give a stderr redirection'
+          end
+        else
+          errors << "merge_output must be true or false but was #{merge_output.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/lib/process_executer/options/spawn_options.rb
+++ b/lib/process_executer/options/spawn_options.rb
@@ -14,6 +14,12 @@ module ProcessExecuter
     # @api public
     #
     class SpawnOptions < Base
+      # Options that are passed to Process.spawn
+      #
+      # They are not passed of the value is :not_set
+      #
+      # @return [Array<OptionDefinition>]
+      #
       SPAWN_OPTIONS = [
         OptionDefinition.new(:unsetenv_others, default: :not_set),
         OptionDefinition.new(:pgroup, default: :not_set),
@@ -66,11 +72,25 @@ module ProcessExecuter
       # @api private
       def stdout_redirection?(option_key) = std_redirection?(option_key, :out, 1)
 
+      # Determine the option key that indicates a redirection option for stdout
+      # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # @api private
+      def stdout_redirection_key
+        options.keys.find { |option_key| option_key if stdout_redirection?(option_key) }
+      end
+
       # Determine if the given option key indicates a redirection option for stderr
       # @param option_key [Symbol, Integer, IO, Array] the option key to be tested
       # @return [Boolean]
       # @api private
       def stderr_redirection?(option_key) = std_redirection?(option_key, :err, 2)
+
+      # Determine the option key that indicates a redirection option for stderr
+      # @return [Symbol, Integer, IO, Array, nil] nil if not found
+      # @api private
+      def stderr_redirection_key
+        options.keys.find { |option_key| option_key if stderr_redirection?(option_key) }
+      end
 
       private
 

--- a/lib/process_executer/result_with_capture.rb
+++ b/lib/process_executer/result_with_capture.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module ProcessExecuter
+  # A decorator for ProcessExecuter::Result that adds the following attributes:
+  #
+  # * `stdout`: the captured stdout of the command
+  # * `stderr`: the captured stderr of the command
+  #
+  # @api public
+  #
+  class ResultWithCapture < SimpleDelegator
+    # Create a new ResultWithCapture object
+    #
+    # @param result [ProcessExecuter::Result] the result to delegate to
+    # @param stdout_buffer [StringIO] the captured stdout
+    # @param stderr_buffer [StringIO] the captured stderr
+    #
+    # @example
+    #   stdout_buffer = StringIO.new
+    #   stderr_buffer = StringIO.new
+    #   command = ['echo HELLO; echo ERROR >&2']
+    #   result = ProcessExecuter.run('echo HELLO; echo ERROR >&2', out: stdout_buffer, err: stderr_buffer)
+    #   result_with_capture = ProcessExecuter::ResultWithCapture.new(result, stdout_buffer:, stderr_buffer:)
+    #   result_with_capture.success? #=> true
+    #   result_with_capture.stdout #=> "HELLO\n"
+    #   result_with_capture.stderr #=> "ERROR\n"
+    #
+    # @api public
+    #
+    def initialize(result, stdout_buffer:, stderr_buffer:)
+      super(result)
+      @stdout_buffer = stdout_buffer
+      @stderr_buffer = stderr_buffer
+    end
+
+    # The buffer used to capture stdout
+    # @example
+    #   result.stdout_buffer #=> #<StringIO:0x00007f8c1b0a2d80>
+    # @return [StringIO]
+    attr_reader :stdout_buffer
+
+    # The captured stdout of the command
+    # @example
+    #   result.stdout #=> "HELLO\n"
+    # @return [String]
+    def stdout = @stdout_buffer.string
+
+    # The buffer used to capture stderr
+    # @example
+    #   result.stderr_buffer #=> #<StringIO:0x00007f8c1b0a2d80>
+    # @return [StringIO]
+    attr_reader :stderr_buffer
+
+    # The captured stderr of the command
+    # @example
+    #   result.stderr #=> "ERROR\n"
+    # @return [String]
+    def stderr = @stderr_buffer.string
+  end
+end

--- a/lib/process_executer/runner.rb
+++ b/lib/process_executer/runner.rb
@@ -3,7 +3,7 @@
 require_relative 'errors'
 
 module ProcessExecuter
-  # `Runner` runs a subprocess, blocks until it completes, and returns the result
+  # Run a command and return the result
   #
   # This class is a wrapper around {ProcessExecuter.spawn_with_timeout} which itself is
   # a wrapper around `Process.spawn`. It takes the same options as both of these methodds

--- a/lib/process_executer/runner_with_capture.rb
+++ b/lib/process_executer/runner_with_capture.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'errors'
+
+module ProcessExecuter
+  # `Runner` runs a subprocess, blocks until it completes, and returns the result
+  #
+  # This class is a wrapper around {ProcessExecuter.spawn_with_timeout} which itself is
+  # a wrapper around `Process.spawn`. It takes the same options as both of these methodds
+  # plus `raise_errors:` and `logger:`.
+  #
+  # This class wraps any stdout or stderr redirection destinations in a {MonitoredPipe}.
+  # This allows any class that implements `#write` to be use as an output redirection
+  # destination. This means that you can redirect to a StringIO which is not possible
+  # with `Process.spawn`.
+  #
+  # @api public
+  #
+  class RunnerWithCapture < Runner
+    # Run a command and return the result which includes the captured output
+    #
+    # @example
+    #   runner = ProcessExecuter::Runner.new()
+    #   result = runner.call('echo hello')
+    #   result = ProcessExecuter.run('echo hello')
+    #   result.success? # => true
+    #   result.exitstatus # => 0
+    #
+    # @param command [Array<String>] The command to run
+    # @param options [ProcessExecuter::Options::RunOptions] Options for running the command
+    #
+    # @return [ProcessExecuter::Result] The result of the completed subprocess
+    #
+    def call(command, options)
+      stdout_buffer = StringIO.new
+      stderr_buffer = StringIO.new
+
+      options.merge!(**capture_options(options, stdout_buffer, stderr_buffer))
+
+      result = super
+
+      ProcessExecuter::ResultWithCapture.new(result, stdout_buffer:, stderr_buffer:)
+    end
+
+    private
+
+    # Determine the out and err options to add to the command options
+    #
+    # @param options [ProcessExecuter::Options::RunWithCaptureOptions] The options for the command
+    # @param stdout_buffer [StringIO] The buffer to capture stdout
+    # @param stderr_buffer [StringIO] The buffer to capture stderr
+    #
+    # @return [Hash] The options to add to the command
+    #
+    # @api private
+    #
+    def capture_options(options, stdout_buffer, stderr_buffer)
+      {}.tap do |capture_options|
+        capture_options[:out] = stdout_buffer unless options.stdout_redirection_key
+        if options.merge_output
+          capture_options[:err] = [:child, 1]
+        else
+          capture_options[:err] = stderr_buffer unless options.stderr_redirection_key
+        end
+      end
+    end
+
+    # Process the result of the command and return a ProcessExecuter::Result
+    #
+    # Log the command and result, and raise an error if the command failed.
+    #
+    # @param result [ProcessExecuter::Result] The result of the command
+    #
+    # @return [Void]
+    #
+    # @raise [ProcessExecuter::Error] if the command could not be executed or failed
+    #
+    # @api private
+    #
+    # def process_result(result)
+    #   log_result(result)
+    #   raise_errors(result) if result.options.raise_errors
+    # end
+  end
+end

--- a/spec/process_executer_run_with_capture_spec.rb
+++ b/spec/process_executer_run_with_capture_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'logger'
+require 'tmpdir'
+
+RSpec.describe ProcessExecuter do
+  describe '.run_with_capture' do
+    let!(:command) do
+      command_separator = windows? ? '&' : ';'
+      ["echo HELLO#{command_separator} echo ERROR>&2"]
+    end
+
+    let!(:eol) do
+      windows? ? "\r\n" : "\n"
+    end
+
+    describe 'options' do
+      context 'with no options' do
+        it 'should run the command and return a result with the captured output' do
+          expect(described_class.run_with_capture(*command)).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: "HELLO#{eol}",
+                stderr: "ERROR#{eol}"
+              )
+            )
+          )
+        end
+      end
+
+      context 'with an options_hash' do
+        it 'should run the command and return a result with the captured output' do
+          options = { merge_output: true }
+          expect(described_class.run_with_capture(*command, **options)).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: include("HELLO#{eol}").and(include("ERROR#{eol}")),
+                stderr: ''
+              )
+            )
+          )
+        end
+
+        context 'with an invalid option' do
+          it 'raises a ProcessExecuter::ArgumentError' do
+            options = { invalid_option: true }
+            expect { described_class.run_with_capture(*command, **options) }.to(
+              raise_error(ProcessExecuter::ArgumentError)
+            )
+          end
+        end
+      end
+
+      context 'with an options object' do
+        context 'when the options object is a ProcessExecuter::Options::RunWithCaptureOptions' do
+          it 'should run the command and return a result with the captured output' do
+            options = ProcessExecuter::Options::RunWithCaptureOptions.new(merge_output: true)
+            expect(described_class.run_with_capture(*command, options)).to(
+              be_a(ProcessExecuter::ResultWithCapture).and(
+                have_attributes(
+                  stdout: include("HELLO#{eol}").and(include("ERROR#{eol}")),
+                  stderr: ''
+                )
+              )
+            )
+          end
+        end
+
+        context 'when the options object is some other kind of object' do
+          it 'raises a ProcessExecuter::SpawnError' do
+            options = Object.new
+            expect { described_class.run_with_capture(*command, options) }.to(
+              raise_error(ProcessExecuter::SpawnError)
+            )
+          end
+        end
+      end
+    end
+
+    context 'when the user gives an invalid merge_output value' do
+      it 'raises a ProcessExecuter::ArgumentError' do
+        options = { merge_output: 'invalid' }
+        expect { described_class.run_with_capture(*command, **options) }.to(
+          raise_error(ProcessExecuter::ArgumentError)
+        )
+      end
+    end
+
+    context 'when the user overrides stdout or stderr capture' do
+      context 'when the user gives a stdout redirection' do
+        it 'overrides the stdout capture' do
+          my_stdout_buffer = StringIO.new
+          options = { out: my_stdout_buffer }
+          expect(described_class.run_with_capture(*command, **options)).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: '',
+                stderr: "ERROR#{eol}"
+              )
+            )
+          )
+          expect(my_stdout_buffer.string).to eq("HELLO#{eol}")
+        end
+      end
+
+      context 'when the user gives a stdout redirection and merge_output: true' do
+        it 'overrides the stdout capture' do
+          my_stdout_buffer = StringIO.new
+          options = { out: my_stdout_buffer, merge_output: true }
+          expect(described_class.run_with_capture(*command, **options)).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: '',
+                stderr: ''
+              )
+            )
+          )
+          expect(my_stdout_buffer.string).to include("HELLO#{eol}").and(include("ERROR#{eol}"))
+        end
+      end
+
+      context 'when the user gives a stderr redirection' do
+        it 'overrides the stderr capture' do
+          my_stderr_buffer = StringIO.new
+          options = { err: my_stderr_buffer }
+          expect(described_class.run_with_capture(*command, **options)).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: "HELLO#{eol}",
+                stderr: ''
+              )
+            )
+          )
+          expect(my_stderr_buffer.string).to eq("ERROR#{eol}")
+        end
+      end
+
+      context 'when the user gives a stderr redirection and merge_output: true' do
+        it 'raises a ProcessExecuter::ArgumentError' do
+          my_stderr_buffer = StringIO.new
+          options = { err: my_stderr_buffer, merge_output: true }
+          expect { described_class.run_with_capture(*command, **options) }.to(
+            raise_error(ProcessExecuter::ArgumentError)
+          )
+        end
+      end
+    end
+
+    context 'when given a command that runs successfully and sends output to stdout and stderr' do
+      it 'should run the command and return a result with the captured output' do
+        result = nil
+        expect { result = described_class.run_with_capture(*command) }.not_to raise_error
+        expect(result).to(
+          be_a(ProcessExecuter::ResultWithCapture).and(
+            have_attributes(
+              stdout: "HELLO#{eol}",
+              stderr: "ERROR#{eol}"
+            )
+          )
+        )
+      end
+
+      context 'when merge_output is false' do
+        it 'should run the command and return a result with output for stdout and stderr captured separately' do
+          result = nil
+          options = { merge_output: false }
+          expect { result = described_class.run_with_capture(*command, **options) }.not_to raise_error
+          expect(result).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(
+                stdout: "HELLO#{eol}",
+                stderr: "ERROR#{eol}"
+              )
+            )
+          )
+        end
+      end
+
+      context 'when merge_output is true' do
+        it 'should run the command and return a result with output for stdout and stderr captured in stdout' do
+          result = nil
+          options = { merge_output: true }
+          expect { result = described_class.run_with_capture(*command, **options) }.not_to raise_error
+          expect(result).to(
+            be_a(ProcessExecuter::ResultWithCapture).and(
+              have_attributes(stdout: including("HELLO#{eol}")).and(
+                have_attributes(stdout: including("ERROR#{eol}"))
+              )
+            )
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Wraps `run` and automatically captures stdout and stderr

The captured output is accessed in the returned object's stdout and stderr
methods. Merged output (if the `merged_output: true` option is given) is
accessed in the stdout method.

stdout and stderr redirection options may be given by the caller. This will
override the capture if given. This means that if an stdout redirection is given,
the result.stdout will be empty and if a stderr redirection is given, the
result.stderr will be empty. A `ProcessExecuter::ArgumentError` will be raised if
both a stderr redirection and the `merge_output: true` option are given.

Accepts the same options as {run} and adds the following option:

* `:merge_output` to merge stdout and stderr into a single capture buffer (default is false)

A `ProcessExecuter::ArgumentError` will be raised if both an options object and
an options_hash are given.