### PR TITLE
build: add irb as development dependency

### DIFF
--- a/process_executer.gemspec
+++ b/process_executer.gemspec
@@ -60,6 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov-rspec', '~> 0.3'
 
   unless RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'irb', '~> 1.6'
     spec.add_development_dependency 'redcarpet', '~> 3.6'
     spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     spec.add_development_dependency 'yardstick', '~> 0.9'


### PR DESCRIPTION
IRB was extracted from Ruby's standard library in Ruby 3.4.0 and is no longer included by default. YARD depends on IRB for certain features (such as documentation generation and console commands), so it must now be explicitly added as a development dependency to ensure YARD functions correctly.

Without this dependency, YARD may fail when attempting to use IRB-related functionality during documentation generation.