### PR TITLE
ci: add Ruby 4.0 to continuous integration test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ env:
   JRUBY_OPTS: --debug
 
 # Tested platforms / Ruby versions:
-#  - Ubuntu: MRI (3.1, 3.2, 3.3, 3.4), TruffleRuby (24), JRuby (9.4)
+#  - Ubuntu: MRI (3.1, 3.4, 4.0), TruffleRuby (24), JRuby (9.4), JRuby (10.0)
 #  - Windows: MRI (3.1)
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.4"]
+        ruby: ["3.1", "3.4", "4.0"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: [true]
         java_version: [""]


### PR DESCRIPTION
Add Ruby 4.0 to the continuous integration test matrix to ensure the gem is compatible with the latest Ruby version.

Changes:
- Added Ruby 4.0 to the test matrix alongside existing Ruby 3.1 and 3.4
- Updated documentation comments to reflect Ruby 4.0 and JRuby 10.0 support

This ensures we catch any compatibility issues with Ruby 4.0 early in the development cycle.