### PR TITLE
docs: update Ruby version support policy

### DIFF
--- a/.github/workflows/process-spawn-test.yml
+++ b/.github/workflows/process-spawn-test.yml
@@ -1,0 +1,43 @@
+name: Process.spawn Test
+
+# Test that Process.spawn sets status correctly on JRuby for Windows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["ruby", "jruby"]
+        operating-system: [ubuntu-latest, windows-latest]
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        if: startsWith(matrix.ruby, 'jruby')
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: .
+
+      - name: Show Java version
+        if: startsWith(matrix.ruby, 'jruby')
+        run: |
+          ruby -e "puts %Q(Java version: #{java.lang.System.getProperty(%q(java.version))})"
+
+      - name: Run tests
+        run: cd process_spawn_test && bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -20,15 +20,8 @@ RubyGems.org. Go to the [process_executer page in
 RubyGems.org](https://rubygems.org/gems/process_executer), select your version, and
 then click the "Documentation" link.
 
-## Requirements
-
-- Ruby 3.1.0 or later
-- Compatible with MRI 3.1+, TruffleRuby 24+, and JRuby 9.4+
-- Works on Mac, Linux, and Windows platforms
-
 ## Table of contents
 
-- [Requirements](#requirements)
 - [Table of contents](#table-of-contents)
 - [Usage](#usage)
   - [Key methods](#key-methods)
@@ -36,6 +29,7 @@ then click the "Documentation" link.
   - [Encoding](#encoding)
     - [Encoding summary](#encoding-summary)
     - [Encoding details](#encoding-details)
+- [Ruby version support policy](#ruby-version-support-policy)
 - [Breaking Changes](#breaking-changes)
   - [2.x](#2x)
     - [`ProcessExecuter.spawn`](#processexecuterspawn)
@@ -198,6 +192,26 @@ These encoding options ONLY affect the internally captured stdout and stderr for
 `ProcessExecuter::run_with_capture`. If you give an `out:` or `err:` option, these
 will result in BINARY encoded strings and you will need to handle setting the right
 encoding or transcoding after collecting the output.
+
+## Ruby version support policy
+
+This gem will be expected to function correctly on:
+
+- All [non-EOL versions](https://www.ruby-lang.org/en/downloads/branches/) of the MRI
+  Ruby on Mac, Linux, and Windows
+- The latest version of JRuby 9.4+ on Linux
+- The latest version of TruffleRuby 24+ on Linux
+
+It is this project's intent to support the latest version of JRuby on Windows once
+Process.wait2 and Process.wait work correctly on this platform.
+
+Currently, JRuby on Windows does not capture and report the subprocess status via $?
+(or $CHILD_STATUS), Process.wait, or Process.wait2. These values always return `nil`
+for the status, preventing this gem from properly detecting command failures and
+timeouts.
+
+This repository includes a separate test suite in the `process_spawn_test/`
+directory that specifically validates JRuby's subprocess behavior. The [Process Spawn Test workflow](.github/workflows/process-spawn-test.yml) can be run manually to verify the status of this issue.
 
 ## Breaking Changes
 

--- a/process_spawn_test/.rspec
+++ b/process_spawn_test/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper.rb
+--color
+--format documentation

--- a/process_spawn_test/README.md
+++ b/process_spawn_test/README.md
@@ -1,0 +1,36 @@
+# Process Spawn Test
+
+These tests verify that `Process.spawn`, `Process.wait`, and `Process.wait2` work
+correctly across different Ruby implementations and operating systems.
+
+This test suite is particularly important for verifying JRuby behavior on Windows,
+where historically there have been issues with subprocess status reporting.
+
+## Tests
+
+The test suite includes:
+
+* Test that `Process#wait` sets the global `$CHILD_STATUS` variable
+* Test that `Process#wait2` returns a non-nil status
+
+## Running the Tests
+
+There is no Gemfile in `process_spawn_test/`, so bundler walks up to the repo root and uses the main project's Gemfile. From the repository root:
+
+```bash
+cd process_spawn_test && bundle exec rspec
+```
+
+Alternatively, you can stay at the root and run:
+
+```bash
+bundle exec rspec process_spawn_test/spec/test_spec.rb
+```
+
+## GitHub Actions Workflow
+
+The workflow file `.github/workflows/process-spawn-test.yml` can be manually triggered to run these tests on:
+- MRI Ruby and JRuby
+- Ubuntu (Linux) and Windows
+
+To run the workflow, go to the Actions tab in GitHub and select "Process.spawn Test" from the workflow list.

--- a/process_spawn_test/spec/spec_helper.rb
+++ b/process_spawn_test/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/process_spawn_test/spec/test_spec.rb
+++ b/process_spawn_test/spec/test_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'English'
+
+RSpec.describe 'Process#wait' do
+  it 'sets the global $CHILD_STATUS variable' do
+    pid = Process.spawn('ruby', '-e', 'exit 0')
+    Process.wait(pid)
+    expect($CHILD_STATUS).not_to be_nil
+    expect($CHILD_STATUS.pid).to eq(pid)
+  end
+end
+
+RSpec.describe 'Process#wait2' do
+  it 'returns a non-nil status' do
+    pid = Process.spawn('ruby', '-e', 'exit 0')
+    _pid, status = Process.wait2(pid)
+    expect(status).not_to be_nil
+    expect(status.pid).to eq(pid)
+  end
+end


### PR DESCRIPTION
## Summary

This PR updates the Ruby version support policy documentation and adds a test suite to verify Process.spawn behavior across different Ruby implementations.

## Changes

### Documentation
- Replace "Requirements" section with comprehensive "Ruby version support policy"
- Link to Ruby maintenance schedule for non-EOL version definition
- Document JRuby Windows limitation with subprocess status reporting
- Reference the new in-repo test suite for verifying JRuby fixes

### Test Suite
- Add `process_spawn_test/` directory with minimal test suite
- Tests validate `Process.wait` and `Process.wait2` properly return status
- Tests use `ruby -e "exit 0"` - no external dependencies
- Isolated configuration (runs from within directory to avoid main project config)
- Add GitHub Actions workflow (manual trigger only) to test on:
  - MRI Ruby and JRuby
  - Ubuntu (Linux) and Windows

## Testing

```bash
cd process_spawn_test && bundle exec rspec
```

All tests pass on MRI Ruby. The workflow can be manually triggered to verify the current status on JRuby/Windows.

## Related Issues

Addresses the need to document and verify the JRuby Windows subprocess status issue.