### PR TITLE
chore: bump GitHub Actions to v5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install updated version of Java if matrix.java_version is set
       - name: Initialize Java
         if: matrix.java_version != ''
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@
 
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with: { fetch-depth: 0 }
 
         - name: Check Commit Messages

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -58,11 +58,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize Java
         if: matrix.java_version != ''
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/process-spawn-test.yml
+++ b/.github/workflows/process-spawn-test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Setup Java
         if: startsWith(matrix.ruby, 'jruby')
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create release
         uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- bump actions/checkout to v5
- bump actions/setup-java to v5

## Testing
- not run (workflow changes only)
