### PR TITLE
ci: fix process-spawn workflow

### DIFF
--- a/.github/workflows/process-spawn-test.yml
+++ b/.github/workflows/process-spawn-test.yml
@@ -40,4 +40,5 @@ jobs:
           ruby -e "puts %Q(Java version: #{java.lang.System.getProperty(%q(java.version))})"
 
       - name: Run tests
-        run: cd process_spawn_test && bundle exec rspec
+        working-directory: process_spawn_test
+        run: bundle exec rspec


### PR DESCRIPTION
## Summary
- run process-spawn-test RSpec suite from the process_spawn_test directory so specs are discovered on Windows runners

## Testing
- not run (workflow change)
