### PR TITLE
ci: ensure process-spawn specs run on Windows

### DIFF
--- a/.github/workflows/process-spawn-test.yml
+++ b/.github/workflows/process-spawn-test.yml
@@ -41,4 +41,5 @@ jobs:
 
       - name: Run tests
         working-directory: process_spawn_test
-        run: bundle exec rspec
+        shell: bash
+        run: bundle exec rspec spec/test_spec.rb


### PR DESCRIPTION
## Summary
- run the Process Spawn Test workflow under bash on Windows runners
- explicitly invoke spec/test_spec.rb from the process_spawn_test directory to guarantee discovery

## Testing
- not run (workflow change only)
