### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # Install updated version of Java if matrix.java_version is set
       - name: Initialize Java

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@
 
       steps:
         - name: Checkout
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
           with: { fetch-depth: 0 }
 
         - name: Check Commit Messages

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize Java
         if: matrix.java_version != ''

--- a/.github/workflows/process-spawn-test.yml
+++ b/.github/workflows/process-spawn-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Java
         if: startsWith(matrix.ruby, 'jruby')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflow dependencies to their latest floating major versions.

### Changes

| Action | Old | New | Latest |
|--------|-----|-----|--------|
| `actions/checkout` | `@v5` | `@v6` | v6.0.2 |
| `googleapis/release-please-action` | `@v4` | `@v5` | v5.0.0 |

### Already current (no change needed)

- `actions/setup-java@v5` — latest is still v5 (latest: v5.2.0)
- `ruby/setup-ruby@v1` — latest is still v1 (latest: v1.305.0)
- `wagoid/commitlint-github-action@v6` — latest is still v6 (latest: v6.2.1)
- `rubygems/release-gem@v1` — latest is still v1 (latest: v1.2.0)